### PR TITLE
Add setting for cookies in request headers

### DIFF
--- a/tests/downloads_tests.py
+++ b/tests/downloads_tests.py
@@ -13,7 +13,7 @@ from unittest.mock import patch
 from trafilatura.cli import parse_args
 from trafilatura.cli_utils import download_queue_processing, url_processing_pipeline
 from trafilatura.core import extract
-from trafilatura.downloads import add_to_compressed_dict, fetch_url, decode_response, draw_backoff_url, load_download_buffer, _determine_headers, _handle_response, _parse_config, _send_request
+from trafilatura.downloads import USER_AGENT, add_to_compressed_dict, fetch_url, decode_response, draw_backoff_url, load_download_buffer, _determine_headers, _handle_response, _parse_config, _send_request
 from trafilatura.settings import DEFAULT_CONFIG, use_config
 from trafilatura.utils import load_html
 
@@ -44,8 +44,13 @@ def test_fetch():
     assert load_html(response) is not None
     # nothing to see here
     assert extract(response, url=response.geturl(), config=ZERO_CONFIG) is None
+    # default config is none
+    assert _parse_config(DEFAULT_CONFIG) == (None, None)
+    # default user-agent
+    default = _determine_headers(DEFAULT_CONFIG)
+    assert default['User-Agent'] == USER_AGENT
     # user-agents rotation
-    assert _parse_config(UA_CONFIG) == ['Firefox', 'Chrome']
+    assert _parse_config(UA_CONFIG) == (['Firefox', 'Chrome'], None)
     custom = _determine_headers(UA_CONFIG)
     assert custom['User-Agent'] == 'Chrome' or custom['User-Agent'] == 'Firefox'
 

--- a/tests/downloads_tests.py
+++ b/tests/downloads_tests.py
@@ -49,10 +49,12 @@ def test_fetch():
     # default user-agent
     default = _determine_headers(DEFAULT_CONFIG)
     assert default['User-Agent'] == USER_AGENT
+    assert 'Cookie' not in default
     # user-agents rotation
-    assert _parse_config(UA_CONFIG) == (['Firefox', 'Chrome'], None)
+    assert _parse_config(UA_CONFIG) == (['Firefox', 'Chrome'], 'yummy_cookie=choco; tasty_cookie=strawberry')
     custom = _determine_headers(UA_CONFIG)
     assert custom['User-Agent'] == 'Chrome' or custom['User-Agent'] == 'Firefox'
+    assert custom['Cookie'] == 'yummy_cookie=choco; tasty_cookie=strawberry'
 
 
 def test_queue():

--- a/tests/resources/newsettings.cfg
+++ b/tests/resources/newsettings.cfg
@@ -9,6 +9,8 @@ MIN_FILE_SIZE = 10
 SLEEP_TIME = 0.25
 # user-agents here: agent1,agent2,...
 USER_AGENTS = Firefox,Chrome
+# Cookies for requests
+COOKIES =
 
 # Extraction
 MIN_EXTRACTED_SIZE = 10000

--- a/tests/resources/newsettings.cfg
+++ b/tests/resources/newsettings.cfg
@@ -9,8 +9,8 @@ MIN_FILE_SIZE = 10
 SLEEP_TIME = 0.25
 # user-agents here: agent1,agent2,...
 USER_AGENTS = Firefox,Chrome
-# Cookies for requests
-COOKIES = yummy_cookie=choco; tasty_cookie=strawberry
+# cookie for HTTP requests
+COOKIE = yummy_cookie=choco; tasty_cookie=strawberry
 
 # Extraction
 MIN_EXTRACTED_SIZE = 10000

--- a/tests/resources/newsettings.cfg
+++ b/tests/resources/newsettings.cfg
@@ -10,7 +10,7 @@ SLEEP_TIME = 0.25
 # user-agents here: agent1,agent2,...
 USER_AGENTS = Firefox,Chrome
 # Cookies for requests
-COOKIES =
+COOKIES = yummy_cookie=choco; tasty_cookie=strawberry
 
 # Extraction
 MIN_EXTRACTED_SIZE = 10000

--- a/trafilatura/downloads.py
+++ b/trafilatura/downloads.py
@@ -44,24 +44,30 @@ DEFAULT_HEADERS = {
 LOGGER = logging.getLogger(__name__)
 
 
-#@lru_cache(maxsize=2)
+# caching throws an error
+# @lru_cache(maxsize=2)
 def _parse_config(config):
     'Read and extract HTTP header strings from the configuration file.'
-    myagents = config.get('DEFAULT', 'USER_AGENTS').split(',') or None
-    mycookies = config.get('DEFAULT', 'COOKIES') or None
-    return myagents, mycookies
+    # load a series of user-agents
+    myagents = config.get('DEFAULT', 'USER_AGENTS') or None
+    if myagents is not None and myagents != '':
+        myagents = myagents.split(',')
+    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies
+    # todo: support for several cookies?
+    mycookie = config.get('DEFAULT', 'COOKIE') or None
+    return myagents, mycookie
 
 
 def _determine_headers(config, headers=None):
     'Internal function to decide on user-agent string.'
     if config != DEFAULT_CONFIG:
-        myagents, mycookies = _parse_config(config)
+        myagents, mycookie = _parse_config(config)
         headers = dict()
         if myagents is not None:
             rnumber = random.randint(0, len(myagents) - 1)
             headers['User-Agent'] = myagents[rnumber]
-        if mycookies is not None:
-            headers['Cookie'] = mycookies
+        if mycookie is not None:
+            headers['Cookie'] = mycookie
     return headers or DEFAULT_HEADERS
 
 

--- a/trafilatura/downloads.py
+++ b/trafilatura/downloads.py
@@ -46,22 +46,24 @@ LOGGER = logging.getLogger(__name__)
 
 #@lru_cache(maxsize=2)
 def _parse_config(config):
-    'Read and extract user-agent strings from the configuration file.'
-    mystring = config.get('DEFAULT', 'USER_AGENTS')
-    if mystring is not None and mystring != '':
-        return mystring.split(',')
-    return None
+    'Read and extract HTTP header strings from the configuration file.'
+    myagents = config.get('DEFAULT', 'USER_AGENTS') or None
+    mycookies = config.get('DEFAULT', 'COOKIES') or None
+    return (myagents.split(',') if myagents else None, mycookies)
 
 
 def _determine_headers(config):
     'Internal function to decide on user-agent string.'
     if config != DEFAULT_CONFIG:
-        myagents = _parse_config(config)
+        myagents, mycookies = _parse_config(config)
+        headers = {}
         if myagents is not None:
             rnumber = random.randint(0, len(myagents) - 1)
-            return {
-            'User-Agent': myagents[rnumber],
-            }
+            headers['User-Agent'] = myagents[rnumber]
+        if mycookies is not None:
+            headers['Cookie'] = mycookies
+        if headers:
+            return headers
     return DEFAULT_HEADERS
 
 

--- a/trafilatura/downloads.py
+++ b/trafilatura/downloads.py
@@ -47,24 +47,22 @@ LOGGER = logging.getLogger(__name__)
 #@lru_cache(maxsize=2)
 def _parse_config(config):
     'Read and extract HTTP header strings from the configuration file.'
-    myagents = config.get('DEFAULT', 'USER_AGENTS') or None
+    myagents = config.get('DEFAULT', 'USER_AGENTS').split(',') or None
     mycookies = config.get('DEFAULT', 'COOKIES') or None
-    return (myagents.split(',') if myagents else None, mycookies)
+    return myagents, mycookies
 
 
-def _determine_headers(config):
+def _determine_headers(config, headers=None):
     'Internal function to decide on user-agent string.'
     if config != DEFAULT_CONFIG:
         myagents, mycookies = _parse_config(config)
-        headers = {}
+        headers = dict()
         if myagents is not None:
             rnumber = random.randint(0, len(myagents) - 1)
             headers['User-Agent'] = myagents[rnumber]
         if mycookies is not None:
             headers['Cookie'] = mycookies
-        if headers:
-            return headers
-    return DEFAULT_HEADERS
+    return headers or DEFAULT_HEADERS
 
 
 def _send_request(url, no_ssl, config):

--- a/trafilatura/settings.cfg
+++ b/trafilatura/settings.cfg
@@ -9,6 +9,8 @@ MIN_FILE_SIZE = 10
 SLEEP_TIME = 2
 # user-agents here: agent1,agent2,...
 USER_AGENTS =
+# Cookies for requests
+COOKIES =
 
 # Extraction
 MIN_EXTRACTED_SIZE = 200

--- a/trafilatura/settings.cfg
+++ b/trafilatura/settings.cfg
@@ -9,8 +9,8 @@ MIN_FILE_SIZE = 10
 SLEEP_TIME = 2
 # user-agents here: agent1,agent2,...
 USER_AGENTS =
-# Cookies for requests
-COOKIES =
+# cookie for HTTP requests
+COOKIE =
 
 # Extraction
 MIN_EXTRACTED_SIZE = 200


### PR DESCRIPTION
This PR adds the ability for setting cookies in request headers. Cookies may sometimes be required to access pages behind a login or some kind of consent page.

Might be a partial solution for #53.

Note: This solution works for zeit.de by using something like `config['DEFAULT']['COOKIES'] = 'zonconsent=' + datetime.now().isoformat()` for the cookie header.