### PR TITLE
fix documentation build: pin docutils to 0.17

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 # without version specifier
 trafilatura
 pydata-sphinx-theme
+docutils==0.17.1


### PR DESCRIPTION
Sphinx build was failing because of this issue https://github.com/sphinx-doc/sphinx/issues/9788

Pinning docutils seems easier than upgrading Sphinx from 1.8 to > 4.0

In the future you might want to look into upgrading Sphinx