### PR TITLE
fix CLI tests on Windows on GitHub actions

### DIFF
--- a/tests/cli_tests.py
+++ b/tests/cli_tests.py
@@ -93,7 +93,11 @@ def test_climain():
     empty_input = b'<html><body></body></html>'
     assert subprocess.run([trafilatura_bin], input=empty_input).returncode == 0
     # input directory walking and processing
-    assert subprocess.run([trafilatura_bin, '--inputdir', RESOURCES_DIR]).returncode == 0
+    env = os.environ.copy()
+    if os.name == 'nt':
+        # Force encoding to utf-8 for Windows (seem to be a problem only in GitHub Actions)
+        env['PYTHONIOENCODING'] = 'utf-8'
+    assert subprocess.run([trafilatura_bin, '--inputdir', RESOURCES_DIR], env=env).returncode == 0
 
 
 def test_input_type():


### PR DESCRIPTION
I could reproduce this issue with PowerShell on Windows, this patch made the tests pass.

I tested on a Windows with Git Bash and the basic command line and didn't reproduce, even by manually setting the problematic code page with `chcp 1252` (default is code page 850)

I didn't test on the latest Windows 10 but I think everything should also work fine on [WSL](https://en.wikipedia.org/wiki/Windows_Subsystem_for_Linux). I don't think there is anything to document or to patch outside of unit tests