### PR TITLE
Minor optimizations and fixes

### DIFF
--- a/trafilatura/cli_utils.py
+++ b/trafilatura/cli_utils.py
@@ -33,7 +33,7 @@ from courlan import get_host_and_path, is_navigation_page, validate_url
 from .core import extract
 from .downloads import add_to_compressed_dict, buffered_downloads, load_download_buffer
 from .filters import content_fingerprint
-from .utils import uniqify_list
+from .utils import uniquify_list
 from .settings import (use_config, FILENAME_LEN,
                        FILE_PROCESSING_CORES, MAX_FILES_PER_DIRECTORY)
 from .spider import get_crawl_delay, init_crawl, process_response
@@ -72,7 +72,7 @@ def load_input_urls(args):
     elif args.sitemap:
         input_urls = [args.sitemap]
     # uniq URLs while preserving order (important)
-    return uniqify_list(input_urls)
+    return uniquify_list(input_urls)
 
 
 def load_blacklist(filename):

--- a/trafilatura/cli_utils.py
+++ b/trafilatura/cli_utils.py
@@ -33,6 +33,7 @@ from courlan import get_host_and_path, is_navigation_page, validate_url
 from .core import extract
 from .downloads import add_to_compressed_dict, buffered_downloads, load_download_buffer
 from .filters import content_fingerprint
+from .utils import uniqify_list
 from .settings import (use_config, FILENAME_LEN,
                        FILE_PROCESSING_CORES, MAX_FILES_PER_DIRECTORY)
 from .spider import get_crawl_delay, init_crawl, process_response
@@ -71,7 +72,7 @@ def load_input_urls(args):
     elif args.sitemap:
         input_urls = [args.sitemap]
     # uniq URLs while preserving order (important)
-    return list(OrderedDict.fromkeys(input_urls))
+    return uniqify_list(input_urls)
 
 
 def load_blacklist(filename):

--- a/trafilatura/core.py
+++ b/trafilatura/core.py
@@ -408,11 +408,11 @@ def handle_textelem(element, potential_tags, dedupbool, config):
 def delete_by_link_density(subtree, tagname, backtracking=False):
     '''Determine the link density of elements with respect to their length,
        and remove the elements identified as boilerplate.'''
-    myelems, deletions = dict(), list()
+    myelems, deletions = dict(), set()
     for elem in subtree.iter(tagname):
         result, templist = link_density_test(elem)
         if result is True:
-            deletions.append(elem)
+            deletions.add(elem)
         elif backtracking is True and len(templist) > 0:
             text = trim(elem.text_content())
             if text not in myelems:
@@ -423,11 +423,11 @@ def delete_by_link_density(subtree, tagname, backtracking=False):
     if backtracking is True:
         for text, elem in myelems.items():
             if 0 < len(text) < 100 and len(elem) >= 3:
-                deletions.extend(elem)
+                deletions.update(elem)
                 # print('backtrack:', text)
             # else: # and not re.search(r'[?!.]', text):
             # print(elem.tag, templist)
-    for elem in list(OrderedDict.fromkeys(deletions)):
+    for elem in deletions:
         elem.getparent().remove(elem)
     return subtree
 
@@ -544,8 +544,8 @@ def extract_comments(tree, dedupbool, config):
         #    processed_elem = process_comments_node(elem, potential_tags)
         #    if processed_elem is not None:
         #        comments_body.append(processed_elem)
-        processed_elems = [process_comments_node(elem, potential_tags, dedupbool, config) for elem in subtree.xpath('.//*')]
-        comments_body.extend(list(filter(None.__ne__, processed_elems)))
+        processed_elems = (process_comments_node(elem, potential_tags, dedupbool, config) for elem in subtree.xpath('.//*'))
+        comments_body.extend(elem for elem in processed_elems if elem is not None)
         # control
         if len(comments_body) > 0:  # if it has children
             LOGGER.debug(expr)

--- a/trafilatura/core.py
+++ b/trafilatura/core.py
@@ -26,7 +26,7 @@ from .htmlprocessing import (convert_tags, handle_textnode,
                              process_node, prune_unwanted_nodes, tree_cleaning)
 from .metadata import extract_metadata, METADATA_LIST
 from .settings import use_config, DEFAULT_CONFIG, TAG_CATALOG
-from .utils import load_html, trim, txttocsv, is_image_file
+from .utils import load_html, trim, txttocsv, uniqify_list, is_image_file
 from .xml import (build_json_output, build_xml_output, build_tei_output,
                   control_xml_output, xmltotxt)
 from .xpaths import (BODY_XPATH, COMMENTS_XPATH, COMMENTS_DISCARD_XPATH, DISCARD_XPATH,
@@ -408,11 +408,11 @@ def handle_textelem(element, potential_tags, dedupbool, config):
 def delete_by_link_density(subtree, tagname, backtracking=False):
     '''Determine the link density of elements with respect to their length,
        and remove the elements identified as boilerplate.'''
-    myelems, deletions = dict(), set()
+    myelems, deletions = {}, []
     for elem in subtree.iter(tagname):
         result, templist = link_density_test(elem)
         if result is True:
-            deletions.add(elem)
+            deletions.append(elem)
         elif backtracking is True and len(templist) > 0:
             text = trim(elem.text_content())
             if text not in myelems:
@@ -423,11 +423,11 @@ def delete_by_link_density(subtree, tagname, backtracking=False):
     if backtracking is True:
         for text, elem in myelems.items():
             if 0 < len(text) < 100 and len(elem) >= 3:
-                deletions.update(elem)
+                deletions.extend(elem)
                 # print('backtrack:', text)
             # else: # and not re.search(r'[?!.]', text):
             # print(elem.tag, templist)
-    for elem in deletions:
+    for elem in uniqify_list(deletions):
         elem.getparent().remove(elem)
     return subtree
 

--- a/trafilatura/core.py
+++ b/trafilatura/core.py
@@ -26,7 +26,7 @@ from .htmlprocessing import (convert_tags, handle_textnode,
                              process_node, prune_unwanted_nodes, tree_cleaning)
 from .metadata import extract_metadata, METADATA_LIST
 from .settings import use_config, DEFAULT_CONFIG, TAG_CATALOG
-from .utils import load_html, trim, txttocsv, uniqify_list, is_image_file
+from .utils import load_html, trim, txttocsv, uniquify_list, is_image_file
 from .xml import (build_json_output, build_xml_output, build_tei_output,
                   control_xml_output, xmltotxt)
 from .xpaths import (BODY_XPATH, COMMENTS_XPATH, COMMENTS_DISCARD_XPATH, DISCARD_XPATH,
@@ -427,7 +427,7 @@ def delete_by_link_density(subtree, tagname, backtracking=False):
                 # print('backtrack:', text)
             # else: # and not re.search(r'[?!.]', text):
             # print(elem.tag, templist)
-    for elem in uniqify_list(deletions):
+    for elem in uniquify_list(deletions):
         elem.getparent().remove(elem)
     return subtree
 

--- a/trafilatura/downloads.py
+++ b/trafilatura/downloads.py
@@ -20,7 +20,7 @@ from courlan import get_host_and_path, validate_url
 
 from . import __version__
 from .settings import DEFAULT_CONFIG, DOWNLOAD_THREADS, TIMEOUT
-from .utils import decode_response, uniqify_list
+from .utils import decode_response, uniquify_list
 
 # customize headers
 RETRY_STRATEGY = urllib3.util.Retry(
@@ -147,7 +147,7 @@ def add_to_compressed_dict(inputlist, blacklist=None, url_filter=None, inputdict
     if inputdict is None:
         inputdict = defaultdict(deque)
     # deduplicate while keeping order
-    inputlist = uniqify_list(inputlist)
+    inputlist = uniquify_list(inputlist)
     # filter
     if blacklist:
         inputlist = [u for u in inputlist if re.sub(r'https?://', '', u) not in blacklist]

--- a/trafilatura/downloads.py
+++ b/trafilatura/downloads.py
@@ -20,7 +20,7 @@ from courlan import get_host_and_path, validate_url
 
 from . import __version__
 from .settings import DEFAULT_CONFIG, DOWNLOAD_THREADS, TIMEOUT
-from .utils import decode_response
+from .utils import decode_response, uniqify_list
 
 # customize headers
 RETRY_STRATEGY = urllib3.util.Retry(
@@ -147,7 +147,7 @@ def add_to_compressed_dict(inputlist, blacklist=None, url_filter=None, inputdict
     if inputdict is None:
         inputdict = defaultdict(deque)
     # deduplicate while keeping order
-    inputlist = list(OrderedDict.fromkeys(inputlist))
+    inputlist = uniqify_list(inputlist)
     # filter
     if blacklist:
         inputlist = [u for u in inputlist if re.sub(r'https?://', '', u) not in blacklist]

--- a/trafilatura/external.py
+++ b/trafilatura/external.py
@@ -114,7 +114,7 @@ def sanitize_tree(tree, include_formatting=False, include_links=False, include_i
         elem.getparent().remove(elem)
     # elements to be stripped
     stripped_set = MANUALLY_STRIPPED.copy()
-    stripped_set.update('a', 'span')
+    stripped_set.update(('a', 'span'))
     if include_links is True:
         stripped_set.remove('a')
     if include_images is True:

--- a/trafilatura/external.py
+++ b/trafilatura/external.py
@@ -113,12 +113,13 @@ def sanitize_tree(tree, include_formatting=False, include_links=False, include_i
     for elem in tree.xpath(sanitized_xpath):
         elem.getparent().remove(elem)
     # elements to be stripped
-    stripped_list = MANUALLY_STRIPPED + ['a', 'span']
+    stripped_set = MANUALLY_STRIPPED.copy()
+    stripped_set.update('a', 'span')
     if include_links is True:
-        stripped_list.remove('a')
+        stripped_set.remove('a')
     if include_images is True:
-        stripped_list.remove('img')
-    etree.strip_tags(tree, stripped_list)
+        stripped_set.remove('img')
+    etree.strip_tags(tree, *stripped_set)
     tree = prune_html(tree)
     # convert
     cleaned_tree = convert_tags(tree, include_formatting=include_formatting, include_links=include_links, include_images=include_images)
@@ -138,6 +139,6 @@ def sanitize_tree(tree, include_formatting=False, include_links=False, include_i
         if tagname not in TEI_VALID_TAGS
     ]
 
-    etree.strip_tags(cleaned_tree, sanitization_list)
+    etree.strip_tags(cleaned_tree, *sanitization_list)
     text = trim(' '.join(cleaned_tree.itertext()))
     return cleaned_tree, text, len(text)

--- a/trafilatura/external.py
+++ b/trafilatura/external.py
@@ -113,13 +113,12 @@ def sanitize_tree(tree, include_formatting=False, include_links=False, include_i
     for elem in tree.xpath(sanitized_xpath):
         elem.getparent().remove(elem)
     # elements to be stripped
-    stripped_set = MANUALLY_STRIPPED.copy()
-    stripped_set.update(('a', 'span'))
+    stripped_list = MANUALLY_STRIPPED + ['a', 'span']
     if include_links is True:
-        stripped_set.remove('a')
+        stripped_list.remove('a')
     if include_images is True:
-        stripped_set.remove('img')
-    etree.strip_tags(tree, *stripped_set)
+        stripped_list.remove('img')
+    etree.strip_tags(tree, *stripped_list)
     tree = prune_html(tree)
     # convert
     cleaned_tree = convert_tags(tree, include_formatting=include_formatting, include_links=include_links, include_images=include_images)

--- a/trafilatura/htmlprocessing.py
+++ b/trafilatura/htmlprocessing.py
@@ -42,24 +42,24 @@ HTML_CLEANER.style = False
 
 def tree_cleaning(tree, include_tables, include_images=False):
     '''Prune the tree by discarding unwanted elements'''
-    # determine cleaning strategy
-    cleaning_set, stripping_set = \
+    # determine cleaning strategy, use lists to keep it deterministic
+    cleaning_list, stripping_list = \
         MANUALLY_CLEANED.copy(), MANUALLY_STRIPPED.copy()
     if include_tables is False:
-        cleaning_set.add('table')
+        cleaning_list.append('table')
     if include_images is True:
         # Many websites have <img> inside <figure> or <picture> or <source> tag
-        cleaning_list = [e for e in cleaning_set if e
+        cleaning_list = [e for e in cleaning_list if e
                          not in ('figure', 'picture', 'source')]
-        stripping_set.remove('img')
+        stripping_list.remove('img')
     # delete targeted elements
-    for expression in cleaning_set:
+    for expression in cleaning_list:
         for element in tree.getiterator(expression):
             try:
                 element.drop_tree() # faster when applicable
             except AttributeError:
                 element.getparent().remove(element)
-    HTML_CLEANER.kill_tags, HTML_CLEANER.remove_tags = cleaning_set, stripping_set
+    HTML_CLEANER.kill_tags, HTML_CLEANER.remove_tags = cleaning_list, stripping_list
     # save space and processing time
     return HTML_CLEANER.clean_html(prune_html(tree))
 

--- a/trafilatura/htmlprocessing.py
+++ b/trafilatura/htmlprocessing.py
@@ -43,23 +43,23 @@ HTML_CLEANER.style = False
 def tree_cleaning(tree, include_tables, include_images=False):
     '''Prune the tree by discarding unwanted elements'''
     # determine cleaning strategy
-    cleaning_list, stripping_list = \
+    cleaning_set, stripping_set = \
         MANUALLY_CLEANED.copy(), MANUALLY_STRIPPED.copy()
     if include_tables is False:
-        cleaning_list.append('table')
+        cleaning_set.add('table')
     if include_images is True:
         # Many websites have <img> inside <figure> or <picture> or <source> tag
-        cleaning_list = [e for e in cleaning_list if e
+        cleaning_list = [e for e in cleaning_set if e
                          not in ('figure', 'picture', 'source')]
-        stripping_list.remove('img')
+        stripping_set.remove('img')
     # delete targeted elements
-    for expression in cleaning_list:
+    for expression in cleaning_set:
         for element in tree.getiterator(expression):
             try:
                 element.drop_tree() # faster when applicable
             except AttributeError:
                 element.getparent().remove(element)
-    HTML_CLEANER.kill_tags, HTML_CLEANER.remove_tags = cleaning_list, stripping_list
+    HTML_CLEANER.kill_tags, HTML_CLEANER.remove_tags = cleaning_set, stripping_set
     # save space and processing time
     return HTML_CLEANER.clean_html(prune_html(tree))
 

--- a/trafilatura/settings.py
+++ b/trafilatura/settings.py
@@ -50,7 +50,8 @@ CUT_EMPTY_ELEMS = {'article', 'b', 'blockquote', 'dd', 'div', 'dt', 'em',
                    # 'colgroup', 'col',
 #CUT_EMPTY_ELEMS = {'div', 'span'}
 
-MANUALLY_CLEANED = {
+# order could matter, using lists to keep extraction deterministic
+MANUALLY_CLEANED = [
     # important
     'aside', 'embed', 'footer', 'form', 'head', 'iframe', 'menu', 'object', 'script',
     # other content
@@ -61,14 +62,14 @@ MANUALLY_CLEANED = {
     'marquee', 'math', 'menuitem', 'nav', 'noscript', 'optgroup', 'option',
     'output', 'param', 'progress', 'rp', 'rt', 'rtc', 'select', 'source',
     'style', 'track', 'template', 'textarea', 'time', 'use',
-}
+]
 # 'meta', 'hr', 'img', 'data', 'details', 'summary'
 
-MANUALLY_STRIPPED = {
+MANUALLY_STRIPPED = [
     'abbr', 'acronym', 'address', 'bdi', 'bdo', 'big', 'cite', 'data', 'dfn',
     'font', 'hgroup', 'img', 'ins', 'mark', 'meta', 'ruby', 'small', 'tbody',
     'tfoot', 'thead',
-}
+]
 # 'center', 'rb', 'wbr'
 
 TAG_CATALOG = frozenset(['blockquote', 'code', 'del', 'fw', 'head', 'hi', 'lb', 'list', 'p', 'pre', 'quote'])

--- a/trafilatura/settings.py
+++ b/trafilatura/settings.py
@@ -50,7 +50,7 @@ CUT_EMPTY_ELEMS = {'article', 'b', 'blockquote', 'dd', 'div', 'dt', 'em',
                    # 'colgroup', 'col',
 #CUT_EMPTY_ELEMS = {'div', 'span'}
 
-MANUALLY_CLEANED = [
+MANUALLY_CLEANED = {
     # important
     'aside', 'embed', 'footer', 'form', 'head', 'iframe', 'menu', 'object', 'script',
     # other content
@@ -61,14 +61,14 @@ MANUALLY_CLEANED = [
     'marquee', 'math', 'menuitem', 'nav', 'noscript', 'optgroup', 'option',
     'output', 'param', 'progress', 'rp', 'rt', 'rtc', 'select', 'source',
     'style', 'track', 'template', 'textarea', 'time', 'use',
-]
+}
 # 'meta', 'hr', 'img', 'data', 'details', 'summary'
 
-MANUALLY_STRIPPED = [
+MANUALLY_STRIPPED = {
     'abbr', 'acronym', 'address', 'bdi', 'bdo', 'big', 'cite', 'data', 'dfn',
     'font', 'hgroup', 'img', 'ins', 'mark', 'meta', 'ruby', 'small', 'tbody',
     'tfoot', 'thead',
-]
+}
 # 'center', 'rb', 'wbr'
 
 TAG_CATALOG = frozenset(['blockquote', 'code', 'del', 'fw', 'head', 'hi', 'lb', 'list', 'p', 'pre', 'quote'])

--- a/trafilatura/utils.py
+++ b/trafilatura/utils.py
@@ -12,10 +12,9 @@ import logging
 import re
 import sys
 
+from collections import OrderedDict
 from functools import lru_cache
 from html import unescape
-from collections import OrderedDict
-
 
 # CChardet is faster and can be more accurate
 try:

--- a/trafilatura/utils.py
+++ b/trafilatura/utils.py
@@ -366,7 +366,7 @@ def uniquify_list(l):
 
     https://www.peterbe.com/plog/fastest-way-to-uniquify-a-list-in-python-3.6
     """
-    if sys.version_info > (3, 6):  # only 
+    if sys.version_info > (3, 6):  # changed when support moved to Python 3.6+
         return list(dict.fromkeys(l))
     else:
         return list(OrderedDict.fromkeys(l))

--- a/trafilatura/utils.py
+++ b/trafilatura/utils.py
@@ -359,14 +359,14 @@ def check_authors(authors, author_blacklist):
         return None
 
 
-def uniqify_list(l):
+def uniquify_list(l):
     """
     Remove duplicates from a list while keeping order in an efficient way
     This depends on Python version: dicts preserve insertion order since Python 3.6
 
     https://www.peterbe.com/plog/fastest-way-to-uniquify-a-list-in-python-3.6
     """
-    if sys.version_info > (3, 6):
+    if sys.version_info > (3, 6):  # only 
         return list(dict.fromkeys(l))
     else:
         return list(OrderedDict.fromkeys(l))

--- a/trafilatura/utils.py
+++ b/trafilatura/utils.py
@@ -14,6 +14,7 @@ import sys
 
 from functools import lru_cache
 from html import unescape
+from collections import OrderedDict
 
 
 # CChardet is faster and can be more accurate
@@ -357,3 +358,16 @@ def check_authors(authors, author_blacklist):
         return '; '.join(new_authors).strip('; ')
     else:
         return None
+
+
+def uniqify_list(l):
+    """
+    Remove duplicates from a list while keeping order in an efficient way
+    This depends on Python version: dicts preserve insertion order since Python 3.6
+
+    https://www.peterbe.com/plog/fastest-way-to-uniquify-a-list-in-python-3.6
+    """
+    if sys.version_info > (3, 6):
+        return list(dict.fromkeys(l))
+    else:
+        return list(OrderedDict.fromkeys(l))


### PR DESCRIPTION
### Description

I don't expect a major performance improvement from these little changes, these are small nits.

To get a major improvement, I think iterating on documents in a single-pass (using `etree.iterparse` instead of using lots of `etree.xpath`) would be the way to go


### Detais

- add `utils.unifiqy_list()` to factor `list(OrderedDict.from_keys())`
It turns out that we don't need OrderedDict anymore for this since Python 3.6 and it's much faster with a simple `dict`

- use generators in `extract_comments()` instead of building lists

- use sets instead of lists for `MANUALLY_STRIPPED` and `MANUALLY_CLEANED`
  using ` .remove()` on a list is slow (`O(n)`) so a set seemed more appropriate. It probably doesn't make a difference given the size of these sequences though..

- pass `*seq` in `etree.strip_tags(tree, seq)`
  It seems that it works with a list too but it shouldn't according to the method signature

### Additional notes

Note on uniqify benchmark: I used this simple benchmark:

```python
import random
import time

seq = [random.randrange(0,100000) for i in range(1000000)]

t = time.time()
dedup = list(dict.fromkeys(seq))
print(time.time() - t)
```

to compare OrderedDict and Dict
and also tried using lists with random strings inspired by this code: https://gist.github.com/peterbe/67b9e40af60a1d5bcb1cfb4b2937b088