### PR TITLE
Revert "build(deps): bump docutils from 0.17.1 to 0.18 (#133)"

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 # with version specifier
 Sphinx==4.2.0
 pydata-sphinx-theme==0.7.1
-docutils==0.18
+docutils==0.17.1
 # without version specifier
 trafilatura


### PR DESCRIPTION
This reverts commit 68c63aca82f6fc6635f45fc4b4a8177946a7941d.