### PR TITLE
Bugfix when articleSection is null - json_metadata

### DIFF
--- a/tests/json_metadata_tests.py
+++ b/tests/json_metadata_tests.py
@@ -89,7 +89,7 @@ def test_json_extraction():
 }
 </script>
 </body></html>'''), metadata)
-    print(metadata)
+
     assert metadata is not None and metadata['title'] == 'Apple Spring Forward Event Live Blog'
 
     metadata = dict.fromkeys(METADATA_LIST)
@@ -125,4 +125,32 @@ def test_json_extraction():
 </script>
 </body></html>'''), metadata)
     assert metadata is not None and metadata['author'] == 'Douglas Noel Adams'
+
+    metadata = dict.fromkeys(METADATA_LIST)
+    metadata = extract_meta_json(html.fromstring('''
+<html><body>
+    <script type="application/ld+json">
+        {
+            "@context":"https://schema.org",
+            "@graph":[
+                {
+                    "@type": "Article",
+                    "author":{
+                        "name":"John Smith"
+                    },
+                    "keywords": [
+                        "SAFC",
+                        "Warwick Thornton"
+                    ],
+                    "articleSection": [
+                        null
+                    ],
+                    "inLanguage": "en-AU"
+                }
+            ]
+        }
+    </script>
+</script>
+</body></html>'''), metadata)
+    assert metadata is not None and len(metadata['categories']) == 0
 

--- a/trafilatura/json_metadata.py
+++ b/trafilatura/json_metadata.py
@@ -90,7 +90,7 @@ def extract_json(schema, metadata):
                     if isinstance(content['articleSection'], str):
                         metadata['categories'] = [content['articleSection']]
                     else:
-                        metadata['categories'] = content['articleSection']
+                        metadata['categories'] = list(filter(None, content['articleSection']))
 
                 # try to extract title
                 if metadata['title'] is None:


### PR DESCRIPTION
I found some sites that in articleSection the value is null and it was breaking the package.

Example:
```json
"articleSection": [
    null
],
```

Solution: Remove any null from articleSection tag