### PR TITLE
Fixes to unicode characters on tags and description

### DIFF
--- a/tests/metadata_tests.py
+++ b/tests/metadata_tests.py
@@ -224,6 +224,8 @@ def test_description():
     '''Test the extraction of descriptions'''
     metadata = extract_metadata('<html><head><meta itemprop="description" content="Description"/></head><body></body></html>')
     assert metadata.description == 'Description'
+    metadata = extract_metadata('<html><head><meta property="og:description" content="&amp;#13; A Northern Territory action plan, which includes plans to support development and employment on Aboriginal land, has received an update. &amp;#13..." /></head><body></body></html>')
+    assert metadata.description == 'A Northern Territory action plan, which includes plans to support development and employment on Aboriginal land, has received an update. ...'
 
 
 def test_dates():
@@ -278,6 +280,8 @@ def test_catstags():
     assert metadata.categories == ['Cat1', 'Cat2']
     metadata = extract_metadata('<html><body><p class="entry-tags"><a href="https://example.org/tags/tag1/">Tag1</a>, <a href="https://example.org/tags/tag2/">Tag2</a></p></body></html>')
     assert metadata.tags == ['Tag1', 'Tag2']
+    metadata = extract_metadata('<html><head><meta name="keywords" content="sodium, salt, paracetamol, blood, pressure, high, heart, &amp;quot, intake, warning, study, &amp;quot, medicine, dissolvable, cardiovascular" /></head></html>')
+    assert metadata.tags == ['sodium, salt, paracetamol, blood, pressure, high, heart, intake, warning, study, medicine, dissolvable, cardiovascular']
 
 
 def test_license():

--- a/trafilatura/metadata.py
+++ b/trafilatura/metadata.py
@@ -15,7 +15,7 @@ from lxml import html
 
 from .json_metadata import extract_json, extract_json_parse_error
 from .metaxpaths import author_xpaths, categories_xpaths, tags_xpaths, title_xpaths, author_discard_xpaths
-from .utils import line_processing, load_html, normalize_authors, trim, check_authors, normalize_tags, normalize_string
+from .utils import check_authors, line_processing, load_html, normalize_authors, normalize_tags, trim, unescape
 from .htmlprocessing import prune_unwanted_nodes
 
 LOGGER = logging.getLogger(__name__)
@@ -115,27 +115,27 @@ def extract_opengraph(tree):
             continue
         # site name
         if elem.get('property') == 'og:site_name':
-            site_name = elem.get('content')
+            site_name = trim(unescape(elem.get('content')))
         # blog title
         elif elem.get('property') == 'og:title':
-            title = elem.get('content')
+            title = trim(unescape(elem.get('content')))
         # orig URL
         elif elem.get('property') == 'og:url':
             if validate_url(elem.get('content'))[0] is True:
-                url = elem.get('content')
+                url = trim(unescape(elem.get('content')))
         # description
         elif elem.get('property') == 'og:description':
-            description = normalize_string(elem.get('content'))
+            description = trim(unescape(elem.get('content')))
         # og:author
         elif elem.get('property') in OG_AUTHOR:
-            author = elem.get('content')
+            author = trim(unescape(elem.get('content')))
         # og:type
         # elif elem.get('property') == 'og:type':
         #    pagetype = elem.get('content')
         # og:locale
         # elif elem.get('property') == 'og:locale':
         #    pagelocale = elem.get('content')
-    return trim(title), trim(author), trim(url), trim(description), trim(site_name)
+    return title, author, url, description, site_name
 
 
 def examine_meta(tree):

--- a/trafilatura/metadata.py
+++ b/trafilatura/metadata.py
@@ -15,7 +15,7 @@ from lxml import html
 
 from .json_metadata import extract_json, extract_json_parse_error
 from .metaxpaths import author_xpaths, categories_xpaths, tags_xpaths, title_xpaths, author_discard_xpaths
-from .utils import line_processing, load_html, normalize_authors, trim, check_authors
+from .utils import line_processing, load_html, normalize_authors, trim, check_authors, normalize_tags, normalize_string
 from .htmlprocessing import prune_unwanted_nodes
 
 LOGGER = logging.getLogger(__name__)
@@ -125,7 +125,7 @@ def extract_opengraph(tree):
                 url = elem.get('content')
         # description
         elif elem.get('property') == 'og:description':
-            description = elem.get('content')
+            description = normalize_string(elem.get('content'))
         # og:author
         elif elem.get('property') in OG_AUTHOR:
             author = elem.get('content')
@@ -162,7 +162,7 @@ def examine_meta(tree):
             if elem.get('property').startswith('og:'):
                 continue
             if elem.get('property') == 'article:tag':
-                tags.append(content_attr)
+                tags.append(normalize_tags(content_attr))
             elif elem.get('property') in PROPERTY_AUTHOR:
                 author = normalize_authors(author, content_attr)
         # name attribute
@@ -188,7 +188,7 @@ def examine_meta(tree):
                     url = content_attr
             # keywords
             elif name_attr in METANAME_TAG:  # 'page-topic'
-                tags.append(content_attr)
+                tags.append(normalize_tags(content_attr))
         elif 'itemprop' in elem.attrib:
             if elem.get('itemprop') == 'author':
                 author = normalize_authors(author, content_attr)

--- a/trafilatura/utils.py
+++ b/trafilatura/utils.py
@@ -54,8 +54,6 @@ NOPRINT_TRANS_TABLE = {
     if not chr(i).isprintable() and not chr(i).isspace()
 }
 
-TAG_REMOVE_SPECIAL = re.compile(r'["\']')
-
 # Regex to check image file extensions
 IMAGE_EXTENSION = re.compile(r'[^\s]+\.(jpe?g|png|gif|bmp)(\b|$)')
 
@@ -73,6 +71,8 @@ AUTHOR_EMOJI_REMOVE = re.compile(
     u"\U00002500-\U00002BEF" u"\U00002702-\U000027B0" u"\U000024C2-\U0001F251"
     u"\U0001f926-\U0001f937" u"\U00010000-\U0010ffff" u"\u2640-\u2642" u"\u2600-\u2B55" u"\u200d"
     u"\u23cf" u"\u23e9" u"\u231a" u"\ufe0f" u"\u3030" "]+", flags=re.UNICODE)
+
+CLEAN_META_TAGS = re.compile(r'["\']')
 
 
 def handle_gz_file(filecontent):
@@ -281,16 +281,10 @@ def trim(string):
         return None
 
 
-def normalize_string(string):
-    '''Remove special characters of string'''
-    return trim(unescape(string))
-
-
 def normalize_tags(tags):
     '''Remove special characters of tags'''
-    tags = TAG_REMOVE_SPECIAL.sub(r'', normalize_string(tags))
+    tags = CLEAN_META_TAGS.sub(r'', trim(unescape(tags)))
     tags = list(filter(None, tags.split(", ")))
-
     return ", ".join(tags)
 
 

--- a/trafilatura/utils.py
+++ b/trafilatura/utils.py
@@ -54,6 +54,7 @@ NOPRINT_TRANS_TABLE = {
     if not chr(i).isprintable() and not chr(i).isspace()
 }
 
+TAG_REMOVE_SPECIAL = re.compile(r'["\']')
 
 # Regex to check image file extensions
 IMAGE_EXTENSION = re.compile(r'[^\s]+\.(jpe?g|png|gif|bmp)(\b|$)')
@@ -278,6 +279,19 @@ def trim(string):
         return SPACE_TRIMMING.sub(r' ', NO_TAG_SPACE.sub(r' ', string)).strip(' \t\n\r\v')
     except TypeError:
         return None
+
+
+def normalize_string(string):
+    '''Remove special characters of string'''
+    return trim(unescape(string))
+
+
+def normalize_tags(tags):
+    '''Remove special characters of tags'''
+    tags = TAG_REMOVE_SPECIAL.sub(r'', normalize_string(tags))
+    tags = list(filter(None, tags.split(", ")))
+
+    return ", ".join(tags)
 
 
 def is_image_file(imagesrc):


### PR DESCRIPTION
Hello @adbar , this pull request is to solve a problem when there are unicode characters like `&#13;` in the meta description and when there are syntax errors in the meta keywords like `&quot;`. Thanks.

[hot100fm](https://www.hot100fm.com.au/news/local-news/106966-aboriginal-land-and-sea-action-plan-gets-a-revamp)
Current:
```
..."}
```
Should be: 
```
{"title": "Common Over-The-Counter Painkillers Can Be an Unexpected Source of Too Much Sodium", "author": "Carly Cassella", "hostname": "sciencealert.com", "date": "2022-02-24", "categories": "HEALTH", "tags": "sodium, salt, paracetamol, blood, pressure, high, heart, intake, warning, study, medicine, dissolvable, cardiovascular", "fingerprint": "TZ3gUUfcV
```

[sciencealert](https://www.sciencealert.com/salt-in-common-over-the-counter-painkillers-is-linked-to-cardiovascular-risks)
Current: 
```
"tags": "sodium, salt, paracetamol, blood, pressure, high, heart, ", intake, warning, study, \r\n", medicine, dissolvable, cardiovascular"
```
Should be: "author": "Stephen Teulan; Nikita Weikhardt",

```
"tags": "sodium, salt, paracetamol, blood, pressure, high, heart, intake, warning, study, medicine, dissolvable, cardiovascular"
```