### PR TITLE
Added 'article:author' as meta name

### DIFF
--- a/tests/metadata_tests.py
+++ b/tests/metadata_tests.py
@@ -74,6 +74,8 @@ def test_authors():
     assert metadata.author == 'Jenny Smith; John Smith'
     metadata = extract_metadata('<html><head><meta itemprop="author" content="Jenny Smith and John Smith"/></head><body></body></html>')
     assert metadata.author == 'Jenny Smith; John Smith'
+    metadata = extract_metadata('<html><head><meta name="article:author" content="Jenny Smith"/></head><body></body></html>')
+    assert metadata.author == 'Jenny Smith'
     metadata = extract_metadata('<html><body><a href="" rel="author">Jenny Smith</a></body></html>')
     assert metadata.author == 'Jenny Smith'
     metadata = extract_metadata('<html><body><a href="" rel="author">Jenny "The Author" Smith</a></body></html>')
@@ -169,6 +171,10 @@ def test_dates():
 
 def test_sitename():
     '''Test extraction of site name'''
+    metadata = extract_metadata('<html><head><meta name="article:publisher" content="The Newspaper"/></head><body/></html>')
+    assert metadata.sitename == 'The Newspaper'
+    metadata = extract_metadata('<html><head><meta property="article:publisher" content="The Newspaper"/></head><body/></html>')
+    assert metadata.sitename == 'The Newspaper'
     metadata = extract_metadata('<html><head><title>sitemaps.org - Home</title></head><body/></html>')
     assert metadata.sitename == 'sitemaps.org'
 

--- a/trafilatura/metadata.py
+++ b/trafilatura/metadata.py
@@ -63,8 +63,8 @@ LICENSE_REGEX = re.compile(r'/(by-nc-nd|by-nc-sa|by-nc|by-nd|by-sa|by|zero)/([1-
 TEXT_LICENSE_REGEX = re.compile(r'(cc|creative commons) (by-nc-nd|by-nc-sa|by-nc|by-nd|by-sa|by|zero) ?([1-9]\.[0-9])?', re.I)
 
 METANAME_AUTHOR = {
-    'author', 'byl', 'citation_author', 'dc.creator', 'dc.creator.aut',
-    'dc:creator', 'article:author',
+    'article:author','author', 'byl', 'citation_author',
+    'dc.creator', 'dc.creator.aut', 'dc:creator',
     'dcterms.creator', 'dcterms.creator.aut', 'parsely-author',
     'sailthru.author', 'shareaholic:article_author_name'
 }  # questionable: twitter:creator
@@ -74,8 +74,9 @@ METANAME_DESCRIPTION = {
     'description', 'sailthru.description', 'twitter:description'
 }
 METANAME_PUBLISHER = {
-    'citation_journal_title', 'copyright', 'dc.publisher',
-    'dc:publisher', 'dcterms.publisher', 'publisher'
+    'article:publisher', 'citation_journal_title', 'copyright',
+    'dc.publisher', 'dc:publisher', 'dcterms.publisher',
+    'publisher'
 }  # questionable: citation_publisher
 METANAME_TAG = {
     'citation_keywords', 'dcterms.subject', 'keywords', 'parsely-tags',
@@ -89,6 +90,8 @@ METANAME_TITLE = {
 OG_AUTHOR = {'og:author', 'og:article:author'}
 PROPERTY_AUTHOR = {'author', 'article:author'}
 TWITTER_ATTRS = {'twitter:site', 'application-name'}
+
+# also interesting: article:section & og:type
 
 EXTRA_META = {'charset', 'http-equiv', 'property'}
 
@@ -167,6 +170,8 @@ def examine_meta(tree):
                 tags.append(normalize_tags(content_attr))
             elif elem.get('property') in PROPERTY_AUTHOR:
                 author = normalize_authors(author, content_attr)
+            elif elem.get('property') == 'article:publisher':
+                site_name = site_name or content_attr
         # name attribute
         elif 'name' in elem.attrib:
             name_attr = elem.get('name').lower()

--- a/trafilatura/metadata.py
+++ b/trafilatura/metadata.py
@@ -64,7 +64,7 @@ TEXT_LICENSE_REGEX = re.compile(r'(cc|creative commons) (by-nc-nd|by-nc-sa|by-nc
 
 METANAME_AUTHOR = {
     'author', 'byl', 'citation_author', 'dc.creator', 'dc.creator.aut',
-    'dc:creator',
+    'dc:creator', 'article:author',
     'dcterms.creator', 'dcterms.creator.aut', 'parsely-author',
     'sailthru.author', 'shareaholic:article_author_name'
 }  # questionable: twitter:creator


### PR DESCRIPTION
Hey @adbar I found a case where some sites are using the article:author property as meta name and the code was unable to find the correct names in some cases.

I saw a few Wordpress websites that are using that tag incorrectly. Probably a plugin or some theme with this bug.

example:
Couriermail
https://bit.ly/3MuDGus

```
Current: Lloyd Clarke Hannah Clarke's father
Should be: Lloyd Clarke
```