### PR TITLE
Extend test coverage for json_metadata functions, added fallback to author name when name is a string on article type

### DIFF
--- a/tests/json_metadata_tests.py
+++ b/tests/json_metadata_tests.py
@@ -525,6 +525,56 @@ def test_json_extraction():
 </body></html>'''), metadata)
     assert metadata is not None and metadata.title == "12 words and phrases you need to survive in Hamburg" and metadata.author == "Alexander Johnstone" and metadata.sitename == "The Local"
 
+    metadata = Document()
+    metadata = extract_meta_json(html.fromstring('''
+<html><body>
+    <script type="application/ld+json">
+        {
+            "@context": "https://schema.org",
+            "@graph": [
+                {
+                    "@type": "WebSite",
+                    "@id": "https://a16z.com/#website",
+                    "url": "https://a16z.com/",
+                    "name": "Andreessen Horowitz",
+                    "potentialAction": {
+                        "@type": "SearchAction",
+                        "target": "https://a16z.com/?s={search_term_string}",
+                        "query-input": "required name=search_term_string"
+                    }
+                },
+                {
+                    "@type": "ProfilePage",
+                    "@id": "https://a16z.com/author/ben-horowitz/#webpage",
+                    "url": "https://a16z.com/author/ben-horowitz/",
+                    "inLanguage": "en-US",
+                    "name": "- Andreessen Horowitz",
+                    "isPartOf": {
+                        "@id": "https://a16z.com/#website"
+                    }
+                },
+                {
+                    "@type": [
+                        "Person"
+                    ],
+                    "@id": "https://a16z.com/#/schema/person/2022059d3b1b2ba8b3464ff2cc2e4165",
+                    "name": null,
+                    "image": {
+                        "@type": "ImageObject",
+                        "@id": "https://a16z.com/#authorlogo",
+                        "url": "https://secure.gravatar.com/avatar/?s=96&d=identicon&r=g"
+                    },
+                    "sameAs": [],
+                    "mainEntityOfPage": {
+                        "@id": "https://a16z.com/author/ben-horowitz/#webpage"
+                    }
+                }
+            ]
+        }
+</script>
+</body></html>'''), metadata)
+    assert metadata is not None and metadata.author is None and metadata.sitename == "Andreessen Horowitz"
+
 
 if __name__ == '__main__':
     test_json_extraction()

--- a/tests/json_metadata_tests.py
+++ b/tests/json_metadata_tests.py
@@ -575,6 +575,209 @@ def test_json_extraction():
 </body></html>'''), metadata)
     assert metadata is not None and metadata.author is None and metadata.sitename == "Andreessen Horowitz"
 
+    metadata = Document()
+    metadata = extract_meta_json(html.fromstring('''
+<html><body>
+<script type="application/ld+json">
+{
+  "about":{
+    "@type":"Event",
+    "startDate":"2015-03-09T13:00:00-07:00",
+    "name":"Apple Spring Forward Event"
+  },
+}
+</script>
+</body></html>'''), metadata)
+
+    assert metadata is not None and metadata.author is None and metadata.sitename is None
+
+    metadata = Document()
+    metadata = extract_meta_json(html.fromstring('''
+    <html><body>
+    <script type="application/ld+json">
+    {
+      "about":{
+        "@context":"Event",
+        "startDate":"2015-03-09T13:00:00-07:00",
+        "name":"Apple Spring Forward Event"
+      },
+    }
+    </script>
+    </body></html>'''), metadata)
+
+    assert metadata is not None and metadata.author is None and metadata.sitename is None
+
+    metadata = Document()
+    metadata = extract_meta_json(html.fromstring('''
+<html><body>
+<script type="application/ld+json">
+{
+  "@context":"http://schema.org",
+  "@type":"LiveBlogPosting",
+  "@id":"http://techcrunch.com/2015/03/08/apple-watch-event-live-blog",
+  "about":{
+    "@type":"Event",
+    "startDate":"2015-03-09T13:00:00-07:00",
+    "name":"Apple Spring Forward Event"
+  },
+  "coverageStartTime":"2015-03-09T11:30:00-07:00",
+  "coverageEndTime":"2015-03-09T16:00:00-07:00",
+  "headline":"Apple Spring Forward Event Live Blog",
+  "description":"Welcome to live coverage of the Apple Spring Forward …",
+  "liveBlogUpdate":[{
+      "@type":"BlogPosting",
+      "headline":"Coming this April, HBO NOW will be available exclusively in the U.S. on Apple TV and the App Store.",
+      "datePublished":"2015-03-09T13:08:00-07:00",
+      "articleBody": "It's $14.99 a month.<br> And for a limited time, …"
+    }],
+}
+</script>
+</body></html>'''), metadata)
+    assert metadata is not None and metadata.title == 'Apple Spring Forward Event Live Blog'
+
+    metadata = Document()
+    metadata = extract_meta_json(html.fromstring('''
+<html><body>
+<script type="application/ld+json">
+{
+  "@context":"http://schema.org",
+  "@id":"http://techcrunch.com/2015/03/08/apple-watch-event-live-blog",
+  "about":{
+    "@type":"Event",
+    "startDate":"2015-03-09T13:00:00-07:00",
+    "name":"Apple Spring Forward Event"
+  },
+}
+</script>
+</body></html>'''), metadata)
+    assert metadata is not None and metadata.title is None and metadata.sitename is None
+
+    metadata = Document()
+    metadata = extract_meta_json(html.fromstring('''
+<html><body>
+<script type="application/ld+json">
+{
+        "@context": "http:\/\/schema.org",
+        "@type": "ReportageNewsArticle",
+        "url": "https:\/\/www.bbc.com\/news\/entertainment-arts-51582573",
+        "publisher": {
+            "@type": "NewsMediaOrganization",
+            "name": "BBC News",
+            "publishingPrinciples": "http:\/\/www.bbc.co.uk\/news\/help-41670342",
+            "logo": {
+                "@type": "ImageObject",
+                "url": "https:\/\/www.bbc.co.uk\/news\/special\/2015\/newsspec_10857\/bbc_news_logo.png?cb=1"
+            }
+        },
+        "datePublished": "2020-02-21T05:02:18+00:00",
+        "dateModified": "2020-02-21T05:02:18+00:00",
+        "headline": "EastEnders' June Brown leaves soap 'for good'",
+        "image": {
+            "@type": "ImageObject",
+            "width": 720,
+            "height": 405,
+            "url": "https:\/\/ichef.bbci.co.uk\/news\/720\/cpsprodpb\/B4EE\/production\/_110981364_hi057715325.jpg"
+        },
+        "thumbnailUrl": "https:\/\/ichef.bbci.co.uk\/news\/208\/cpsprodpb\/B4EE\/production\/_110981364_hi057715325.jpg",
+        "author": {
+            "@type": "NewsMediaOrganization",
+            "name": "BBC News",
+            "logo": {
+                "@type": "ImageObject",
+                "url": "https:\/\/www.bbc.co.uk\/news\/special\/2015\/newsspec_10857\/bbc_news_logo.png?cb=1"
+            },
+            "noBylinesPolicy": "http:\/\/www.bbc.co.uk\/news\/help-41670342#authorexpertise"
+        },
+        "mainEntityOfPage": "https:\/\/www.bbc.com\/news\/entertainment-arts-51582573",
+        "video": {
+            "@type": "VideoObject",
+            "name": "June Brown's 90 years in 90 seconds",
+            "description": "EastEnders star June Brown - aka Dot Cotton - is turning 90 on Thursday. Here's a 90-second look back at her life.",
+            "duration": "PT1M36S",
+            "thumbnailUrl": "https:\/\/ichef.bbci.co.uk\/images\/ic\/208x117\/p04t12n5.jpg",
+            "uploadDate": "2017-02-15T18:05:00+00:00"
+        }
+    }
+</script>
+</body></html>'''), metadata)
+
+    assert metadata is not None and metadata.title == "EastEnders' June Brown leaves soap 'for good'" and metadata.sitename == "BBC News"
+
+    metadata = Document()
+    metadata.sitename = "https://bbcnews.com"
+    metadata = extract_meta_json(html.fromstring('''
+    <html><body>
+    <script type="application/ld+json">
+    {
+            "@context": "http:\/\/schema.org",
+            "@type": "ReportageNewsArticle",
+            "url": "https:\/\/www.bbc.com\/news\/entertainment-arts-51582573",
+            "publisher": {
+                "@type": "NewsMediaOrganization",
+                "name": "BBC News",
+                "publishingPrinciples": "http:\/\/www.bbc.co.uk\/news\/help-41670342",
+                "logo": {
+                    "@type": "ImageObject",
+                    "url": "https:\/\/www.bbc.co.uk\/news\/special\/2015\/newsspec_10857\/bbc_news_logo.png?cb=1"
+                }
+            },
+        }
+    </script>
+    </body></html>'''), metadata)
+
+    assert metadata is not None and metadata.sitename == "BBC News"
+
+    metadata = Document()
+    metadata = extract_meta_json(html.fromstring('''
+    <html><body>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "author": "John Doe",
+      "interactionStatistic": [
+        {
+          "@type": "InteractionCounter",
+          "interactionService": {
+            "@type": "WebSite",
+            "name": "Twitter",
+            "url": "http://www.twitter.com"
+          },
+          "interactionType": "https://schema.org/ShareAction",
+          "userInteractionCount": "1203"
+        },
+        {
+          "@type": "InteractionCounter",
+          "interactionType": "https://schema.org/CommentAction",
+          "userInteractionCount": "78"
+        }
+      ],
+      "name": "How to Tie a Reef Knot"
+    }
+    </script>
+    </body></html>'''), metadata)
+
+    assert metadata is not None and metadata.author == "John Doe" and metadata.title == "How to Tie a Reef Knot"
+
+    metadata = Document()
+    metadata = extract_meta_json(html.fromstring('''
+    <html><body>
+        <script type="application/ld+json">
+            {
+                "@context":"http://schema.org",
+                "@type":"NewsArticle",
+                "author":[
+                    {
+                        "@type":"Person",
+                        "name":["Bill Birtles", "John Smith"]
+                    }
+                ]
+            }
+        </script>
+    </script>
+    </body></html>'''), metadata)
+    assert metadata is not None and metadata.author == "Bill Birtles; John Smith"
+
 
 if __name__ == '__main__':
     test_json_extraction()

--- a/tests/json_metadata_tests.py
+++ b/tests/json_metadata_tests.py
@@ -584,7 +584,7 @@ def test_json_extraction():
     "@type":"Event",
     "startDate":"2015-03-09T13:00:00-07:00",
     "name":"Apple Spring Forward Event"
-  },
+  }
 }
 </script>
 </body></html>'''), metadata)
@@ -596,11 +596,24 @@ def test_json_extraction():
     <html><body>
     <script type="application/ld+json">
     {
+      "@context":"http://google.com",
+      "@type":"LiveBlogPosting",
+      "@id":"http://techcrunch.com/2015/03/08/apple-watch-event-live-blog",
       "about":{
-        "@context":"Event",
+        "@type":"Event",
         "startDate":"2015-03-09T13:00:00-07:00",
         "name":"Apple Spring Forward Event"
       },
+      "coverageStartTime":"2015-03-09T11:30:00-07:00",
+      "coverageEndTime":"2015-03-09T16:00:00-07:00",
+      "headline":"Apple Spring Forward Event Live Blog",
+      "description":"Welcome to live coverage of the Apple Spring Forward …",
+      "liveBlogUpdate":[{
+          "@type":"BlogPosting",
+          "headline":"Coming this April, HBO NOW will be available exclusively in the U.S. on Apple TV and the App Store.",
+          "datePublished":"2015-03-09T13:08:00-07:00",
+          "articleBody": "It's $14.99 a month.<br> And for a limited time, …"
+       }]
     }
     </script>
     </body></html>'''), metadata)
@@ -634,23 +647,6 @@ def test_json_extraction():
 </script>
 </body></html>'''), metadata)
     assert metadata is not None and metadata.title == 'Apple Spring Forward Event Live Blog'
-
-    metadata = Document()
-    metadata = extract_meta_json(html.fromstring('''
-<html><body>
-<script type="application/ld+json">
-{
-  "@context":"http://schema.org",
-  "@id":"http://techcrunch.com/2015/03/08/apple-watch-event-live-blog",
-  "about":{
-    "@type":"Event",
-    "startDate":"2015-03-09T13:00:00-07:00",
-    "name":"Apple Spring Forward Event"
-  },
-}
-</script>
-</body></html>'''), metadata)
-    assert metadata is not None and metadata.title is None and metadata.sitename is None
 
     metadata = Document()
     metadata = extract_meta_json(html.fromstring('''
@@ -709,18 +705,18 @@ def test_json_extraction():
     <html><body>
     <script type="application/ld+json">
     {
-            "@context": "http:\/\/schema.org",
-            "@type": "ReportageNewsArticle",
-            "url": "https:\/\/www.bbc.com\/news\/entertainment-arts-51582573",
-            "publisher": {
-                "@type": "NewsMediaOrganization",
-                "name": "BBC News",
-                "publishingPrinciples": "http:\/\/www.bbc.co.uk\/news\/help-41670342",
-                "logo": {
-                    "@type": "ImageObject",
-                    "url": "https:\/\/www.bbc.co.uk\/news\/special\/2015\/newsspec_10857\/bbc_news_logo.png?cb=1"
-                }
-            },
+        "@context": "http:\/\/schema.org",
+        "@type": "ReportageNewsArticle",
+        "url": "https:\/\/www.bbc.com\/news\/entertainment-arts-51582573",
+        "publisher": {
+            "@type": "NewsMediaOrganization",
+            "name": "BBC News",
+            "publishingPrinciples": "http:\/\/www.bbc.co.uk\/news\/help-41670342",
+            "logo": {
+                "@type": "ImageObject",
+                "url": "https:\/\/www.bbc.co.uk\/news\/special\/2015\/newsspec_10857\/bbc_news_logo.png?cb=1"
+            }
+            }
         }
     </script>
     </body></html>'''), metadata)
@@ -777,6 +773,23 @@ def test_json_extraction():
     </script>
     </body></html>'''), metadata)
     assert metadata is not None and metadata.author == "Bill Birtles; John Smith"
+
+    metadata = Document()
+    metadata = extract_meta_json(html.fromstring('''
+    <html><body>
+        <script type="application/ld+json">
+        {
+          "@context":"http://schema.org",
+          "@id":"http://techcrunch.com/2015/03/08/apple-watch-event-live-blog",
+          "about":{
+            "@type":"Event",
+            "startDate":"2015-03-09T13:00:00-07:00",
+            "name":"Apple Spring Forward Event"
+          }
+        }
+        </script>
+    </body></html>'''), metadata)
+    assert metadata is not None and metadata.title is None and metadata.sitename is None
 
 
 if __name__ == '__main__':

--- a/tests/json_metadata_tests.py
+++ b/tests/json_metadata_tests.py
@@ -584,7 +584,7 @@ def test_json_extraction():
     "@type":"Event",
     "startDate":"2015-03-09T13:00:00-07:00",
     "name":"Apple Spring Forward Event"
-  }
+  },
 }
 </script>
 </body></html>'''), metadata)
@@ -613,7 +613,7 @@ def test_json_extraction():
           "headline":"Coming this April, HBO NOW will be available exclusively in the U.S. on Apple TV and the App Store.",
           "datePublished":"2015-03-09T13:08:00-07:00",
           "articleBody": "It's $14.99 a month.<br> And for a limited time, …"
-       }]
+        }],
     }
     </script>
     </body></html>'''), metadata)
@@ -705,18 +705,18 @@ def test_json_extraction():
     <html><body>
     <script type="application/ld+json">
     {
-        "@context": "http:\/\/schema.org",
-        "@type": "ReportageNewsArticle",
-        "url": "https:\/\/www.bbc.com\/news\/entertainment-arts-51582573",
-        "publisher": {
-            "@type": "NewsMediaOrganization",
-            "name": "BBC News",
-            "publishingPrinciples": "http:\/\/www.bbc.co.uk\/news\/help-41670342",
-            "logo": {
-                "@type": "ImageObject",
-                "url": "https:\/\/www.bbc.co.uk\/news\/special\/2015\/newsspec_10857\/bbc_news_logo.png?cb=1"
-            }
-            }
+            "@context": "http:\/\/schema.org",
+            "@type": "ReportageNewsArticle",
+            "url": "https:\/\/www.bbc.com\/news\/entertainment-arts-51582573",
+            "publisher": {
+                "@type": "NewsMediaOrganization",
+                "name": "BBC News",
+                "publishingPrinciples": "http:\/\/www.bbc.co.uk\/news\/help-41670342",
+                "logo": {
+                    "@type": "ImageObject",
+                    "url": "https:\/\/www.bbc.co.uk\/news\/special\/2015\/newsspec_10857\/bbc_news_logo.png?cb=1"
+                }
+            },
         }
     </script>
     </body></html>'''), metadata)
@@ -785,10 +785,11 @@ def test_json_extraction():
             "@type":"Event",
             "startDate":"2015-03-09T13:00:00-07:00",
             "name":"Apple Spring Forward Event"
-          }
+          },
         }
         </script>
     </body></html>'''), metadata)
+
     assert metadata is not None and metadata.title is None and metadata.sitename is None
 
 

--- a/trafilatura/json_metadata.py
+++ b/trafilatura/json_metadata.py
@@ -69,7 +69,8 @@ def extract_json(schema, metadata):
                         try:
                             list_authors = json.loads(list_authors)
                         except json.JSONDecodeError:
-                            pass
+                            # it is a normal string
+                            metadata.author = normalize_authors(metadata.author, list_authors)
 
                     if not isinstance(list_authors, list):
                         list_authors = [list_authors]

--- a/trafilatura/json_metadata.py
+++ b/trafilatura/json_metadata.py
@@ -57,7 +57,7 @@ def extract_json(schema, metadata):
                             metadata.sitename = content[candidate]
 
             elif content_type == "person":
-                if 'name' in content and not content['name'].startswith('http'):
+                if 'name' in content and content['name'] is not None and not content['name'].startswith('http'):
                     metadata.author = normalize_authors(metadata.author, content['name'])
 
             elif content_type in JSON_ARTICLE_SCHEMA:


### PR DESCRIPTION
Hey @adbar,

I'm sending more tests to json metadata functions.

Thanks.

#195 