### PR TITLE
Performance enhancement

### DIFF
--- a/trafilatura/meta.py
+++ b/trafilatura/meta.py
@@ -7,7 +7,7 @@ from htmldate.meta import reset_caches as reset_caches_htmldate
 from justext.core import define_stoplist
 
 from .filters import LRU_TEST
-from .utils import is_printable_or_space, line_processing, trim
+from .utils import line_processing, return_printables_and_spaces, trim
 
 
 def reset_caches() -> None:
@@ -20,8 +20,8 @@ def reset_caches() -> None:
     # courlan
     get_tldinfo.cache_clear()
     # own
-    is_printable_or_space.cache_clear()
     line_processing.cache_clear()
+    return_printables_and_spaces.cache_clear()
     trim.cache_clear()
     LRU_TEST.clear()
 

--- a/trafilatura/meta.py
+++ b/trafilatura/meta.py
@@ -7,7 +7,7 @@ from htmldate.meta import reset_caches as reset_caches_htmldate
 from justext.core import define_stoplist
 
 from .filters import LRU_TEST
-from .utils import line_processing, trim
+from .utils import is_printable_or_space, line_processing, trim
 
 
 def reset_caches() -> None:
@@ -20,6 +20,7 @@ def reset_caches() -> None:
     # courlan
     get_tldinfo.cache_clear()
     # own
+    is_printable_or_space.cache_clear()
     line_processing.cache_clear()
     trim.cache_clear()
     LRU_TEST.clear()

--- a/trafilatura/utils.py
+++ b/trafilatura/utils.py
@@ -219,15 +219,17 @@ def txttocsv(text, comments, docmeta):
     return tsv_output
 
 
-#  sys.maxunicode = 1114111
-@lru_cache(maxsize=1114111)
-def is_printable_or_space(character):
-    return character.isprintable() or character.isspace()
+@lru_cache(maxsize=1114111)  # sys.maxunicode = 1114111
+def return_printables_and_spaces(char):
+    'Return a character if it belongs to certain classes'
+    if char.isprintable() or char.isspace():
+        return char
+    return ''
 
 
 def remove_control_characters(string):
     '''Prevent non-printable and XML invalid character errors'''
-    return ''.join(filter(is_printable_or_space, string))
+    return ''.join(map(return_printables_and_spaces, string))
 
 
 def normalize_unicode(string, unicodeform='NFC'):

--- a/trafilatura/utils.py
+++ b/trafilatura/utils.py
@@ -219,9 +219,15 @@ def txttocsv(text, comments, docmeta):
     return tsv_output
 
 
+#  sys.maxunicode = 1114111
+@lru_cache(maxsize=1114111)
+def is_printable_or_space(character):
+    return character.isprintable() or character.isspace()
+
+
 def remove_control_characters(string):
     '''Prevent non-printable and XML invalid character errors'''
-    return ''.join([c for c in string if c.isprintable() or c.isspace()])
+    return ''.join(filter(is_printable_or_space, string))
 
 
 def normalize_unicode(string, unicodeform='NFC'):


### PR DESCRIPTION
### I. Test file
<details>
  <summary>test2.py</summary>

```python3
from time import time

import requests
from trafilatura import extract


if __name__ == '__main__':
    urls = ["https://en.wikipedia.org/wiki/List_of_Hindi_songs_recorded_by_Asha_Bhosle",
            "https://en.wikipedia.org/wiki/2022_in_video_games",
            "https://en.wikipedia.org/wiki/COVID-19_pandemic_in_Kuwait",
            "https://en.wikipedia.org/wiki/Presidency_of_Rodrigo_Duterte",
            "https://en.wikipedia.org/wiki/List_of_2021%E2%80%9322_NBA_season_transactions",
            "https://en.wikipedia.org/wiki/2022_in_sports",
            "https://en.wikipedia.org/wiki/Firefox_version_history",
            "https://en.wikipedia.org/wiki/List_of_common_misconceptions",
            "https://en.wikipedia.org/wiki/Same-sex_union_legislation",
            "https://en.wikipedia.org/wiki/Presidency_of_Donald_Trump",]

    cum_time = 0
    for url in urls:        
        resp = requests.get(url)
        t0 = time()
        result = extract(resp.text)
        cum_time = cum_time + time() - t0
    print(cum_time)
```
</details>

### II. Test [pprofile](https://pypi.org/project/pprofile/)
```python3
kernprof -lv test2.py
```
before
```python3
Total time: 0.544693 s
File: /trafilatura-master/trafilatura/utils.py
Function: remove_control_characters at line 221

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   221                                           @profile
   222                                           def remove_control_characters(string):
   223                                               '''Prevent non-printable and XML invalid character errors'''
   224     25998     544693.0     21.0    100.0      return ''.join([c for c in string if c.isprintable() or c.isspace()])
```

after
```python3
Total time: 0.169241 s
File: /trafilatura-master/trafilatura/utils.py
Function: remove_control_characters at line 227

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   227                                           @profile
   228                                           def remove_control_characters(string):
   229                                               '''Prevent non-printable and XML invalid character errors'''
   230     25998     169241.0      6.5    100.0      return ''.join(filter(is_printable_or_space, string))
```
### III. Test [vprof](https://pypi.org/project/vprof/)
```python3
vprof -c -h test2.py
```
before
![before](https://user-images.githubusercontent.com/65482418/187427649-64345cd6-cd97-44ca-abe5-13c35bef44a5.jpg)

after
![after](https://user-images.githubusercontent.com/65482418/187427779-23876b2f-38e8-4dcb-b5b3-871b188b1169.jpg)

