### PR TITLE
TEI: Add <publisher> if license is added

### DIFF
--- a/tests/xml_tei_tests.py
+++ b/tests/xml_tei_tests.py
@@ -1,0 +1,73 @@
+"""
+Test for transformation to TEI.
+"""
+from lxml.etree import Element
+
+from trafilatura.metadata import Document
+from trafilatura.xml import write_fullheader
+
+
+def test_publisher_added_before_availability_in_publicationStmt():
+    # add publisher string
+    teidoc = Element("TEI", xmlns="http://www.tei-c.org/ns/1.0")
+    metadata = Document()
+    metadata.sitename = "The Publisher"
+    metadata.license = "CC BY-SA 4.0"
+    metadata.categories = metadata.tags = ["cat"]
+    header = write_fullheader(teidoc, metadata)
+    publicationstmt = header.find(".//{*}fileDesc/{*}publicationStmt")
+    assert [child.tag for child in publicationstmt.getchildren()] == [
+        "publisher",
+        "availability",
+    ]
+    assert publicationstmt[0].text == "The Publisher"
+
+    teidoc = Element("TEI", xmlns="http://www.tei-c.org/ns/1.0")
+    metadata = Document()
+    metadata.hostname = "example.org"
+    metadata.license = "CC BY-SA 4.0"
+    metadata.categories = metadata.tags = ["cat"]
+    header = write_fullheader(teidoc, metadata)
+    publicationstmt = header.find(".//{*}fileDesc/{*}publicationStmt")
+    assert [child.tag for child in publicationstmt.getchildren()] == [
+        "publisher",
+        "availability",
+    ]
+    assert publicationstmt[0].text == "example.org"
+
+    teidoc = Element("TEI", xmlns="http://www.tei-c.org/ns/1.0")
+    metadata = Document()
+    metadata.hostname = "example.org"
+    metadata.sitename = "Example"
+    metadata.license = "CC BY-SA 4.0"
+    metadata.categories = metadata.tags = ["cat"]
+    header = write_fullheader(teidoc, metadata)
+    publicationstmt = header.find(".//{*}fileDesc/{*}publicationStmt")
+    assert [child.tag for child in publicationstmt.getchildren()] == [
+        "publisher",
+        "availability",
+    ]
+    assert publicationstmt[0].text == "Example (example.org)"
+    # no publisher, add "N/A"
+    teidoc = Element("TEI", xmlns="http://www.tei-c.org/ns/1.0")
+    metadata = Document()
+    metadata.categories = metadata.tags = ["cat"]
+    metadata.license = "CC BY-SA 4.0"
+    header = write_fullheader(teidoc, metadata)
+    publicationstmt = header.find(".//{*}fileDesc/{*}publicationStmt")
+    assert [child.tag for child in publicationstmt.getchildren()] == [
+        "publisher",
+        "availability",
+    ]
+    assert publicationstmt[0].text == "N/A"
+    # no license, add nothing
+    teidoc = Element("TEI", xmlns="http://www.tei-c.org/ns/1.0")
+    metadata = Document()
+    metadata.categories = metadata.tags = ["cat"]
+    header = write_fullheader(teidoc, metadata)
+    publicationstmt = header.find(".//{*}fileDesc/{*}publicationStmt")
+    assert [child.tag for child in publicationstmt.getchildren()] == ["p"]
+
+
+if __name__ == "__main__":
+    test_publisher_added_before_availability_in_publicationStmt()

--- a/trafilatura/xml.py
+++ b/trafilatura/xml.py
@@ -320,6 +320,8 @@ def write_fullheader(teidoc, docmeta):
     publicationstmt_a = SubElement(filedesc, 'publicationStmt')
     # license, if applicable
     if docmeta.license:
+        publicationstmt_publisher = SubElement(publicationstmt_a, 'publisher')
+        publicationstmt_publisher.text = _get_publisher_string(docmeta)
         availability = SubElement(publicationstmt_a, 'availability')
         avail_p = SubElement(availability, 'p')
         avail_p.text = docmeta.license

--- a/trafilatura/xml.py
+++ b/trafilatura/xml.py
@@ -294,6 +294,19 @@ def write_teitree(docmeta):
     return teidoc
 
 
+def _get_publisher_string(docmeta):
+    if docmeta.hostname and docmeta.sitename:
+        publisherstring = docmeta.sitename.strip() + ' (' + docmeta.hostname + ')'
+    elif docmeta.hostname:
+        publisherstring = docmeta.hostname
+    elif docmeta.sitename:
+        publisherstring = docmeta.sitename
+    else:
+        LOGGER.warning('no publisher for URL %s', docmeta.url)
+        publisherstring = 'N/A'
+    return publisherstring
+
+
 def write_fullheader(teidoc, docmeta):
     '''Write TEI header based on gathered metadata'''
     header = SubElement(teidoc, 'teiHeader')
@@ -346,16 +359,7 @@ def write_fullheader(teidoc, docmeta):
         bib_author.text = docmeta.author
     publicationstmt = SubElement(biblfull, 'publicationStmt')
     publication_publisher = SubElement(publicationstmt, 'publisher')
-    if docmeta.hostname and docmeta.sitename:
-        publisherstring = docmeta.sitename.strip() + ' (' + docmeta.hostname + ')'
-    elif docmeta.hostname:
-        publisherstring = docmeta.hostname
-    elif docmeta.sitename:
-        publisherstring = docmeta.sitename
-    else:
-        LOGGER.warning('no publisher for URL %s', docmeta.url)
-        publisherstring = 'N/A'
-    publication_publisher.text = publisherstring
+    publication_publisher.text = _get_publisher_string(docmeta)
     if docmeta.url:
         publication_url = SubElement(publicationstmt, 'ptr', type='URL', target=docmeta.url)
     publication_date = SubElement(publicationstmt, 'date')

--- a/trafilatura/xml.py
+++ b/trafilatura/xml.py
@@ -294,7 +294,8 @@ def write_teitree(docmeta):
     return teidoc
 
 
-def _get_publisher_string(docmeta):
+def _define_publisher_string(docmeta):
+    '''Construct a publisher string to include in TEI header'''
     if docmeta.hostname and docmeta.sitename:
         publisherstring = docmeta.sitename.strip() + ' (' + docmeta.hostname + ')'
     elif docmeta.hostname:
@@ -318,10 +319,11 @@ def write_fullheader(teidoc, docmeta):
         bib_author = SubElement(bib_titlestmt, 'author')
         bib_author.text = docmeta.author
     publicationstmt_a = SubElement(filedesc, 'publicationStmt')
+    publisher_string = _define_publisher_string(docmeta)
     # license, if applicable
     if docmeta.license:
         publicationstmt_publisher = SubElement(publicationstmt_a, 'publisher')
-        publicationstmt_publisher.text = _get_publisher_string(docmeta)
+        publicationstmt_publisher.text = publisher_string
         availability = SubElement(publicationstmt_a, 'availability')
         avail_p = SubElement(availability, 'p')
         avail_p.text = docmeta.license
@@ -361,7 +363,7 @@ def write_fullheader(teidoc, docmeta):
         bib_author.text = docmeta.author
     publicationstmt = SubElement(biblfull, 'publicationStmt')
     publication_publisher = SubElement(publicationstmt, 'publisher')
-    publication_publisher.text = _get_publisher_string(docmeta)
+    publication_publisher.text = publisher_string
     if docmeta.url:
         publication_url = SubElement(publicationstmt, 'ptr', type='URL', target=docmeta.url)
     publication_date = SubElement(publicationstmt, 'date')


### PR DESCRIPTION
Changes:
- I moved the extraction of the `publisherstring` in the `write_full_header` function to a separate function to be able to reuse it.
- I changed the `write_full_header` function so that a `<publisher/>` element is added before the `<availability/>` element in  `<publicationStmt/>`. The text that is used for the `<publisher/>` element is the same as in `sourceDesc/biblFull/publicationStmt/publisher`.

Background:
A document is not valid according to TEI P5 if the `fileDesc/publicationStmt` contains an `<availability/>` element but no `<publisher/>`. Therefore, the  `<publisher/>` should also be added before.
