### PR TITLE
Use "\n" for delimiter instead of "," for multiple user-agents

### DIFF
--- a/tests/resources/newsettings.cfg
+++ b/tests/resources/newsettings.cfg
@@ -7,8 +7,13 @@ MAX_FILE_SIZE = 20000000
 MIN_FILE_SIZE = 10
 # sleep between requests
 SLEEP_TIME = 0.25
-# user-agents here: agent1,agent2,...
-USER_AGENTS = Firefox,Chrome
+# List of user-agents. Each user-agent should be put on a new line like so:
+#     "agent1"
+#     "agent2"
+#     ...
+USER_AGENTS =
+    Firefox
+    Chrome
 # cookie for HTTP requests
 COOKIE = yummy_cookie=choco; tasty_cookie=strawberry
 

--- a/trafilatura/downloads.py
+++ b/trafilatura/downloads.py
@@ -65,9 +65,9 @@ RawResponse = namedtuple('RawResponse', ['data', 'status', 'url'])
 def _parse_config(config):
     'Read and extract HTTP header strings from the configuration file.'
     # load a series of user-agents
-    myagents = config.get('DEFAULT', 'USER_AGENTS') or None
+    myagents = config.get('DEFAULT', 'USER_AGENTS').strip() or None
     if myagents is not None and myagents != '':
-        myagents = myagents.split(',')
+        myagents = myagents.split("\n")
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies
     # todo: support for several cookies?
     mycookie = config.get('DEFAULT', 'COOKIE') or None


### PR DESCRIPTION
User-agents can contain the string "," which can lead to malformed
user-agents when using `split(",")`. This commit fixes this issue by
changing the delimiter to a newline ("\n").

Fixes #240.