### PR TITLE
Set tail of element to None if tail was added as text

### DIFF
--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -638,7 +638,23 @@ def test_htmlprocessing():
     my_html = '<html><body><main><p>1</p><p id="paywall">2</p><p>3</p></main></body></html>'
     assert extract(my_html, config=ZERO_CONFIG, no_fallback=True) == '1\n3'
     assert extract(my_html, config=ZERO_CONFIG, no_fallback=False) == '1\n3'
-    
+    # test tail of node deleted if set as text
+    node = etree.fromstring("<div><p></p>tail</div>")[0]
+    trafilatura.htmlprocessing.process_node(node)
+    assert node.text == 'tail'
+    assert node.tail is None
+    node = etree.fromstring("<list><item></item>text in tail</list>")[0]
+    trafilatura.htmlprocessing.process_node(node)
+    assert node.text == "text in tail"
+    assert node.tail is None
+    line_break = etree.fromstring("<p><lb/>tail</p>")[0]
+    trafilatura.htmlprocessing.process_node(line_break)
+    assert line_break.text is None
+    assert line_break.tail == "tail"
+    node = etree.fromstring("<div><p>some text</p>tail</div>")[0]
+    trafilatura.htmlprocessing.process_node(node)
+    assert node.text == "some text"
+    assert node.tail == "tail"
 
 
 def test_extraction_options():

--- a/trafilatura/htmlprocessing.py
+++ b/trafilatura/htmlprocessing.py
@@ -345,6 +345,7 @@ def process_node(element, deduplicate=True, config=DEFAULT_CONFIG):
     # adapt content string
     if element.tag != 'lb' and not element.text and element.tail:
         element.text = element.tail
+        element.tail = None
     # content checks
     if element.text or element.tail:
         if textfilter(element) is True:


### PR DESCRIPTION
Changes: 
- I set the tail of an element to `None` if its tail was added as text in the `process_node` function

In the `process_node` function, the tail of an element is added as text if the element doesn't contain any text but the tails stays the same, so the tail content is duplicated.
 https://github.com/adbar/trafilatura/blob/e81cffe11cb8de03cb177fd2cd3055c7d1824834/trafilatura/htmlprocessing.py#L346-L347

I think the tail should then be set to  `None` (resp. empty string), as in 
 https://github.com/adbar/trafilatura/blob/e81cffe11cb8de03cb177fd2cd3055c7d1824834/trafilatura/htmlprocessing.py#L314-L318

