### PR TITLE
Update quickstart.rst

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -19,7 +19,7 @@ The only required argument is the input document (here a downloaded HTML file), 
     >>> result = trafilatura.extract(downloaded, output_format="xml")
     >>> print(result)
     # formatting preserved in XML structure ...
-    >>> trafilatura.extract(downloaded, xml_output=True, include_comments=False)
+    >>> trafilatura.extract(downloaded, output_format="xml", include_comments=False)
     # outputs main content without comments as XML ...
 
 


### PR DESCRIPTION
The quickstart docs include a deprecated argument. PR changes no-comments example to use `output_format="xml"` as opposed to `xml_output=True`.