### PR TITLE
fix: handle more empty elements

### DIFF
--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -275,6 +275,45 @@ def test_exotic_tags(xmloutput=False):
       <item rend="dd-2">White cold drink</item>
     </list>''' in my_result
 
+    # edge cases
+    htmlstring = '''<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>A weird bug</title>
+  </head>
+  <body>
+      <div>
+        <h1>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</h1>
+        <h2>Sed et interdum lectus.</h2>
+        <p>Quisque molestie nunc eu arcu condimentum fringilla.</p>
+        <!-- strong can be changed to b, em, i, u, or kbd -->
+        <strong><a></a></strong>
+        <h2>Aliquam eget interdum elit, id posuere ipsum.</h2>
+        <p>Phasellus lectus erat, hendrerit sed tortor ac, dignissim vehicula metus.</p>
+      </div>
+  </body>
+</html>'''
+    assert extract(htmlstring, include_formatting=True, include_links=True, include_images=True) is not None
+    htmlstring = '''<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>A weird bug</title>
+  </head>
+  <body>
+    <div id="content">
+      <h1>A header</h1>
+      <h2>Very specific bug so odd</h2>
+      <h3>Nested header</h3>
+      <p>Some "hyphenated-word quote" followed by a bit more text line.</p>
+      <em><p>em improperly wrapping p here</p></em>
+      <p>Text here</p>
+    </div>
+  </body>
+</html>'''
+    assert extract(htmlstring, include_formatting=True, include_links=True, include_images=True) is not None
+
 
 def test_lrucache():
     '''test basic duplicate detection'''

--- a/trafilatura/xml.py
+++ b/trafilatura/xml.py
@@ -182,8 +182,8 @@ def replace_element_text(element, include_formatting):
     '''Determine element text based on text and tail'''
     full_text = ''
     # handle formatting: convert to markdown
-    if include_formatting is True:
-        if element.tag in ('del', 'head') and element.text is not None:
+    if include_formatting is True and element.text is not None:
+        if element.tag in ('del', 'head'):
             if element.tag == 'head':
                 try:
                     number = int(element.get('rend')[1])
@@ -203,14 +203,13 @@ def replace_element_text(element, include_formatting):
                 element.text = ''.join(['`', element.text, '`'])
     # handle links
     if element.tag == 'ref':
-        try:
-            element.text = ''.join(['[', element.text, ']', '(', element.get('target'), ')'])
-        except TypeError:
-            LOGGER.warning('missing link attribute: %s %s', element.text, element.attrib)
-            try:
+        if element.text is not None:
+            if element.get('target') is not None:
+                element.text = ''.join(['[', element.text, ']', '(', element.get('target'), ')'])
+            else:
                 element.text = ''.join(['[', element.text, ']'])
-            except TypeError:
-                LOGGER.error('empty link: %s %s', element.text, element.attrib)
+        else:
+            LOGGER.error('empty link: %s %s', element.text, element.attrib)
     # handle text
     if element.text is not None and element.tail is not None:
         full_text = ''.join([element.text, element.tail])

--- a/trafilatura/xml.py
+++ b/trafilatura/xml.py
@@ -207,6 +207,7 @@ def replace_element_text(element, include_formatting):
             if element.get('target') is not None:
                 element.text = ''.join(['[', element.text, ']', '(', element.get('target'), ')'])
             else:
+                LOGGER.warning('missing link attribute: %s %s', element.text, element.attrib)
                 element.text = ''.join(['[', element.text, ']'])
         else:
             LOGGER.error('empty link: %s %s', element.text, element.attrib)


### PR DESCRIPTION
Missing test coverage.

Related to / continuation of #161.

Fixes #247.

Allows `replace_element_text` to proceed gracefully when `element.text is None`.