### PR TITLE
Handle lists

### DIFF
--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -926,18 +926,18 @@ def test_list_processing():
 </ul>
 </article></body></html>'''
     my_result = extract(htmlstring, no_fallback=True, output_format='xml', config=ZERO_CONFIG)
-    assert '''
+    expected = '''
     <list rend="ul">
       <item>Coffee</item>
-      <item>
-        <item>Tea</item>
+      <item>Tea
         <list rend="ul">
           <item>Black tea</item>
           <item>Green tea</item>
         </list>
       </item>
       <item>Milk</item>
-    </list>''' in my_result
+    </list>'''.replace("\n", "").replace(" ", "")
+    assert expected in my_result.replace("\n", "").replace(" ", "")
     # description list
     htmlstring = '''<html><body><article>
  <dl>
@@ -955,6 +955,19 @@ def test_list_processing():
       <item rend="dt-2">Milk</item>
       <item rend="dd-2">White cold drink</item>
     </list>''' in my_result
+    list_item_with_child = html.fromstring("<list><item><p>text</p></item></list>")
+    processed_list = handle_lists(list_item_with_child, options)
+    result = [(child.tag, child.text) if child.text is not None else child.tag for child in processed_list.iter()]
+    assert result == ["list", "item", ("p", "text")]
+    list_item_with_text_and_child = html.fromstring("<list><item>text1<p>text2</p></item></list>")
+    processed_list = handle_lists(list_item_with_text_and_child, options)
+    result = [(child.tag, child.text) if child.text is not None else child.tag for child in processed_list.iter()]
+    assert result == ["list", ("item", "text1"), ("p", "text2")]
+    list_item_with_lb = html.fromstring("<list><item>text<lb/>more text</item></list>")
+    processed_list = handle_lists(list_item_with_lb, options)
+    result = [(child.tag, child.text) if child.text is not None else child.tag for child in processed_list.iter()]
+    assert result == ["list", ("item", "text"), "lb"]
+
 
 
 if __name__ == '__main__':

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -974,6 +974,28 @@ def test_list_processing():
     empty_list = html.fromstring("<list>   <item>text</item></list>")
     processed_list = handle_lists(empty_list, options)
     assert len(processed_list) == 1
+    list_item_with_tail = html.fromstring("<list><item>text</item>tail</list>")
+    processed_list = handle_lists(list_item_with_tail, options)
+    assert processed_list[0].text == "text tail"
+    list_item_with_child_and_tail = html.fromstring("<list><item><p>text</p></item>tail</list>")
+    processed_list = handle_lists(list_item_with_child_and_tail, options)
+    item_element = processed_list[0]
+    assert item_element.tail is not True
+    assert item_element[0].tail == "tail"
+    list_item_with_child_and_tail = html.fromstring("<list><item><p>text</p>tail1</item>tail</list>")
+    processed_list = handle_lists(list_item_with_child_and_tail, options)
+    item_element = processed_list[0]
+    assert item_element.tail is not True
+    assert item_element[0].tail == "tail1 tail"
+    list_item_with_child_and_tail = html.fromstring("<list><item><p>text</p>\n</item>tail</list>")
+    processed_list = handle_lists(list_item_with_child_and_tail, options)
+    item_element = processed_list[0]
+    assert item_element.tail is not True
+    assert item_element[0].tail == "tail"
+    list_item_with_tail_and_nested_list = html.fromstring("<list><item><list><item>text</item></list></item>tail</list>")
+    processed_list = handle_lists(list_item_with_tail_and_nested_list, options)
+    target_element = processed_list.find(".//item/list")
+    assert target_element.tail == 'tail'
 
 
 if __name__ == '__main__':

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -967,7 +967,10 @@ def test_list_processing():
     processed_list = handle_lists(list_item_with_lb, options)
     result = [(child.tag, child.text) if child.text is not None else child.tag for child in processed_list.iter()]
     assert result == ["list", ("item", "text"), "lb"]
-
+    list_with_text_outside_item = html.fromstring("<list>header<item>text</item></list>")
+    processed_list = handle_lists(list_with_text_outside_item, options)
+    result = [(child.tag, child.text) if child.text is not None else child.tag for child in processed_list.iter()]
+    assert result == ["list", ("item", "header"), ("item", "text")]
 
 
 if __name__ == '__main__':

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -971,6 +971,9 @@ def test_list_processing():
     processed_list = handle_lists(list_with_text_outside_item, options)
     result = [(child.tag, child.text) if child.text is not None else child.tag for child in processed_list.iter()]
     assert result == ["list", ("item", "header"), ("item", "text")]
+    empty_list = html.fromstring("<list>   <item>text</item></list>")
+    processed_list = handle_lists(empty_list, options)
+    assert len(processed_list) == 1
 
 
 if __name__ == '__main__':

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -189,60 +189,12 @@ def test_exotic_tags(xmloutput=False):
     assert etree.tostring(converted) == b'<p>1st part. 2nd part.</p>'
     # naked div with <lb>
     assert '1.\n2.\n3.' in extract('<html><body><main><div>1.<br/>2.<br/>3.<br/></div></main></body></html>', no_fallback=True, config=ZERO_CONFIG)
-    # malformed lists (common error)
-    result = etree.tostring(handle_lists(etree.fromstring('<list>Description of the list:<item>List item 1</item><item>List item 2</item><item>List item 3</item></list>'), options))
-    assert result.count(b'List item') == 3
-    assert b"Description" in result
     # HTML5: <details>
     htmlstring = '<html><body><article><details><summary>Epcot Center</summary><p>Epcot is a theme park at Walt Disney World Resort featuring exciting attractions, international pavilions, award-winning fireworks and seasonal special events.</p></details></article></body></html>'
     my_result = extract(htmlstring, no_fallback=True, config=ZERO_CONFIG)
     assert 'Epcot Center' in my_result and 'award-winning fireworks' in my_result
     my_result = extract(htmlstring, no_fallback=False, config=ZERO_CONFIG)
     assert 'Epcot Center' in my_result and 'award-winning fireworks' in my_result
-    # nested list
-    htmlstring = '''<html><body><article>
-<ul>
-  <li>Coffee</li>
-  <li>Tea
-    <ul>
-      <li>Black tea</li>
-      <li>Green tea</li>
-    </ul>
-  </li>
-  <li>Milk</li>
-</ul>
-</article></body></html>'''
-    my_result = extract(htmlstring, no_fallback=True, output_format='xml', config=ZERO_CONFIG)
-    assert '''
-    <list rend="ul">
-      <item>Coffee</item>
-      <item>
-        <item>Tea</item>
-        <list rend="ul">
-          <item>Black tea</item>
-          <item>Green tea</item>
-        </list>
-      </item>
-      <item>Milk</item>
-    </list>''' in my_result
-    # description list
-    htmlstring = '''<html><body><article>
- <dl>
-  <dt>Coffee</dt>
-  <dd>Black hot drink</dd>
-  <dt>Milk</dt>
-  <dd>White cold drink</dd>
-</dl>
-</article></body></html>'''
-    my_result = extract(htmlstring, no_fallback=True, output_format='xml', config=ZERO_CONFIG)
-    assert '''
-    <list rend="dl">
-      <item rend="dt-1">Coffee</item>
-      <item rend="dd-1">Black hot drink</item>
-      <item rend="dt-2">Milk</item>
-      <item rend="dd-2">White cold drink</item>
-    </list>''' in my_result
-
     # edge cases
     htmlstring = '''<!DOCTYPE html>
 <html>
@@ -954,6 +906,57 @@ def test_table_processing():
     assert result == ["table", "row", "cell", ]
 
 
+def test_list_processing():
+    options = DEFAULT_OPTIONS
+    # malformed lists (common error)
+    result = etree.tostring(handle_lists(etree.fromstring('<list>Description of the list:<item>List item 1</item><item>List item 2</item><item>List item 3</item></list>'), options))
+    assert result.count(b'List item') == 3
+    assert b"Description" in result
+    # nested list
+    htmlstring = '''<html><body><article>
+<ul>
+  <li>Coffee</li>
+  <li>Tea
+    <ul>
+      <li>Black tea</li>
+      <li>Green tea</li>
+    </ul>
+  </li>
+  <li>Milk</li>
+</ul>
+</article></body></html>'''
+    my_result = extract(htmlstring, no_fallback=True, output_format='xml', config=ZERO_CONFIG)
+    assert '''
+    <list rend="ul">
+      <item>Coffee</item>
+      <item>
+        <item>Tea</item>
+        <list rend="ul">
+          <item>Black tea</item>
+          <item>Green tea</item>
+        </list>
+      </item>
+      <item>Milk</item>
+    </list>''' in my_result
+    # description list
+    htmlstring = '''<html><body><article>
+ <dl>
+  <dt>Coffee</dt>
+  <dd>Black hot drink</dd>
+  <dt>Milk</dt>
+  <dd>White cold drink</dd>
+</dl>
+</article></body></html>'''
+    my_result = extract(htmlstring, no_fallback=True, output_format='xml', config=ZERO_CONFIG)
+    assert '''
+    <list rend="dl">
+      <item rend="dt-1">Coffee</item>
+      <item rend="dd-1">Black hot drink</item>
+      <item rend="dt-2">Milk</item>
+      <item rend="dd-2">White cold drink</item>
+    </list>''' in my_result
+
+
 if __name__ == '__main__':
     test_trim()
     test_lrucache()
@@ -971,3 +974,4 @@ if __name__ == '__main__':
     test_external()
     test_tei()
     test_table_processing()
+    test_list_processing()

--- a/trafilatura/core.py
+++ b/trafilatura/core.py
@@ -164,10 +164,12 @@ def handle_lists(element, options):
         if len(child) == 0:
             processed_child = process_node(child, options)
             if processed_child is not None:
-                newchildelem.text, newchildelem.tail = processed_child.text, processed_child.tail
+                newchildelem.text = processed_child.text
+                if processed_child.tail is not None and processed_child.tail.strip():
+                    newchildelem.text += " " + processed_child.tail
                 processed_element.append(newchildelem)
         else:
-            newchildelem.text, newchildelem.tail = child.text, child.tail
+            newchildelem.text = child.text
             # proceed with iteration, fix for nested elements
             for subelem in child.iterdescendants('*'):
                 # beware of nested lists
@@ -185,6 +187,14 @@ def handle_lists(element, options):
                             subchildelem.set('target', subelem.get('target'))
                 # strip_tags(newchildelem, 'item')
                 subelem.tag = 'done'
+            if child.tail is not None and child.tail.strip():
+                newchildelem_children = [el for el in newchildelem.getchildren() if el.tag != 'done']
+                if newchildelem_children:
+                    last_subchild = newchildelem_children[-1]
+                    if last_subchild.tail is None or not last_subchild.tail.strip():
+                        last_subchild.tail = child.tail
+                    else:
+                        last_subchild.tail += ' ' + child.tail
         if newchildelem.text or len(newchildelem) > 0:
             # set attribute
             if child.get('rend') is not None:

--- a/trafilatura/core.py
+++ b/trafilatura/core.py
@@ -166,8 +166,9 @@ def handle_lists(element, options):
                 newchildelem.text, newchildelem.tail = processed_child.text, processed_child.tail
                 processed_element.append(newchildelem)
         else:
+            newchildelem.text, newchildelem.tail = child.text, child.tail
             # proceed with iteration, fix for nested elements
-            for subelem in child.iter('*'):
+            for subelem in child.iterdescendants('*'):
                 # beware of nested lists
                 if subelem.tag == 'list':
                     processed_subchild = handle_lists(subelem, options)

--- a/trafilatura/core.py
+++ b/trafilatura/core.py
@@ -154,7 +154,7 @@ def handle_formatting(element, options):
 def handle_lists(element, options):
     '''Process lists elements'''
     processed_element = Element(element.tag)
-    if element.text is not None:
+    if element.text is not None and element.text.strip():
         newchildelem = SubElement(processed_element, "item")
         newchildelem.text = element.text
     # if element.tail is not None:

--- a/trafilatura/core.py
+++ b/trafilatura/core.py
@@ -155,7 +155,8 @@ def handle_lists(element, options):
     '''Process lists elements'''
     processed_element = Element(element.tag)
     if element.text is not None:
-        processed_element.text = element.text
+        newchildelem = SubElement(processed_element, "item")
+        newchildelem.text = element.text
     # if element.tail is not None:
     #    processed_element.tail = element.text
     for child in element.iter('item'):

--- a/trafilatura/core.py
+++ b/trafilatura/core.py
@@ -201,6 +201,7 @@ def handle_lists(element, options):
                 newchildelem.set('rend', child.get('rend'))
             processed_element.append(newchildelem)
         child.tag = 'done'
+    element.tag = 'done'
     # test if it has children and text. Avoid double tags??
     if len(processed_element) > 0 and text_chars_test(''.join(processed_element.itertext())) is True:
         # set attribute


### PR DESCRIPTION
Changes:
- I gathered all tests that test list processing to in a common function
- I used `iterdescendants` for processing elements in list items to avoid `<item>` as child of `<item>` for items that contain text and other elements.
- I added text content of `<list>` to a new `<item>` element to avoid text in lists that is not wrapped by an item.
- I removed `tail` on `<item>` elements (the tail is added to the `<item>` text or as tail of the last child, if present)
- I set the tag of the list to 'done' after processing (otherwise an empty list might be remain in the output)

I also had to change one of the existing tests for lists (the one for nested lists) because there the result was expected to have `<item>` as child of `<item>`. Unfortunately, the new code also changed the formatting of the result string, so I had to remove whitespace and newline chars for the assert statement to pass.

Background:
 Text in lists that is not wrapped by `<item>`,  tail on `<item>`  or `<item>` as child of `<item>` is not valid in TEI P5.