### PR TITLE
Transform <fw> with subelements to <ab>

### DIFF
--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -648,6 +648,9 @@ def test_tei():
     assert xml.write_fullheader(header, docmeta) is not None
     docmeta.title, docmeta.sitename = None, None
     assert xml.write_fullheader(header, docmeta) is not None
+    htmlstring = html.fromstring("<html><head/><body><div><h2><p>text</p></h2></div></body></html>")
+    extracted = extract(htmlstring, url='mocked', no_fallback=True, output_format="xmltei")
+    assert xml.validate_tei(etree.fromstring(extracted)) is True
 
 
 def test_htmlprocessing():

--- a/tests/xml_tei_tests.py
+++ b/tests/xml_tei_tests.py
@@ -1,10 +1,10 @@
 """
 Test for transformation to TEI.
 """
-from lxml.etree import Element
+from lxml.etree import Element, fromstring
 
 from trafilatura.metadata import Document
-from trafilatura.xml import write_fullheader
+from trafilatura.xml import check_tei, write_fullheader
 
 
 def test_publisher_added_before_availability_in_publicationStmt():
@@ -69,5 +69,61 @@ def test_publisher_added_before_availability_in_publicationStmt():
     assert [child.tag for child in publicationstmt.getchildren()] == ["p"]
 
 
+def test_head_with_children_converted_to_ab():
+    xml_doc = fromstring("<text><head>heading</head><p>some text</p></text>")
+    cleaned = check_tei(xml_doc, "fake_url")
+    result = [
+        (child.tag, child.text) if child.text is not None else child.tag
+        for child in cleaned.iter()
+    ]
+    assert result == ["text", ("fw", "heading"), ("p", "some text")]
+    xml_doc = fromstring("<text><head><p>text</p></head></text>")
+    cleaned = check_tei(xml_doc, "fake_url")
+    result = [(child.tag, child.text, child.tail) for child in cleaned.iter()]
+    assert result == [("text", None, None), ("ab", "text", None)]
+    head_with_mulitple_p = fromstring(
+        "<text><head><p>first</p><p>second</p><p>third</p></head></text>"
+    )
+    cleaned = check_tei(head_with_mulitple_p, "fake_url")
+    result = [(child.tag, child.text, child.tail) for child in cleaned.iter()]
+    # print(result)
+    assert result == [
+        ("text", None, None),
+        ("ab", "first", None),
+        ("lb", None, "second"),
+        ("lb", None, "third"),
+    ]
+    xml_with_complex_head = fromstring(
+        "<text><head><p>first</p><list><item>text</item></list><p>second</p><p>third</p></head></text>"
+    )
+    cleaned = check_tei(xml_with_complex_head, "fake_url")
+    result = [(child.tag, child.text, child.tail) for child in cleaned.iter()]
+    assert result == [
+        ("text", None, None),
+        ("ab", "first", None),
+        ("list", None, "second"),
+        ("item", "text", None),
+        ("lb", None, "third"),
+    ]
+    xml_doc = fromstring("<text><head><list><item>text1</item></list><p>text2</p></head></text>")
+    cleaned = check_tei(xml_doc, "fake_url")
+    result = [(child.tag, child.text, child.tail) for child in cleaned.iter()]
+    assert result == [
+        ("text", None, None),
+        ("ab", None, None),
+        ("list", None, "text2"),
+        ("item", "text1", None)
+    ]
+    xml_doc = fromstring("<text><head>heading</head><p>some text</p></text>")
+    cleaned = check_tei(xml_doc, "fake_url")
+    result = cleaned[0].attrib
+    assert result == {"type":"header"}
+    xml_doc = fromstring("<text><head rend='h3'>heading</head><p>some text</p></text>")
+    cleaned = check_tei(xml_doc, "fake_url")
+    result = cleaned[0].attrib
+    assert result == {"type":"header", "rend":"h3"}
+
+
 if __name__ == "__main__":
     test_publisher_added_before_availability_in_publicationStmt()
+    test_head_with_children_converted_to_ab()

--- a/tests/xml_tei_tests.py
+++ b/tests/xml_tei_tests.py
@@ -127,6 +127,10 @@ def test_head_with_children_converted_to_ab():
     result = cleaned.find(".//ab")
     assert result.text == 'text'
     assert result.attrib == {"type":"header"}
+    xml_doc = fromstring("<text><body><head>text1<p>text2</p></head></body></text>")
+    cleaned = check_tei(xml_doc, "fake_url")
+    result = [(child.tag, child.text, child.tail) for child in cleaned.find(".//ab").iter()]
+    assert result == [("ab", "text1", None), ("lb", None, "text2")]
 
 
 if __name__ == "__main__":

--- a/tests/xml_tei_tests.py
+++ b/tests/xml_tei_tests.py
@@ -122,6 +122,11 @@ def test_head_with_children_converted_to_ab():
     cleaned = check_tei(xml_doc, "fake_url")
     result = cleaned[0].attrib
     assert result == {"type":"header", "rend":"h3"}
+    tei_doc = fromstring("<TEI><teiheader/><text><body><head><p>text</p></head></body></text></TEI>")
+    cleaned = check_tei(tei_doc, "fake_url")
+    result = cleaned.find(".//ab")
+    assert result.text == 'text'
+    assert result.attrib == {"type":"header"}
 
 
 if __name__ == "__main__":

--- a/trafilatura/xml.py
+++ b/trafilatura/xml.py
@@ -24,7 +24,7 @@ from .utils import sanitize
 LOGGER = logging.getLogger(__name__)
 # validation
 TEI_SCHEMA = str(Path(__file__).parent / 'data/tei-schema-pickle.lzma')
-TEI_VALID_TAGS = {'body', 'cell', 'code', 'del', 'div', 'fw', 'graphic', 'head', 'hi', \
+TEI_VALID_TAGS = {'ab', 'body', 'cell', 'code', 'del', 'div', 'fw', 'graphic', 'head', 'hi', \
                   'item', 'lb', 'list', 'p', 'quote', 'ref', 'row', 'table'}
 TEI_VALID_ATTRS = {'rend', 'rendition', 'role', 'target', 'type'}
 TEI_RELAXNG = None  # to be downloaded later if necessary

--- a/trafilatura/xml.py
+++ b/trafilatura/xml.py
@@ -399,6 +399,7 @@ def write_fullheader(teidoc, docmeta):
 
 def _tei_handle_complex_head(element):
     new_element = Element('ab', attrib=element.attrib)
+    new_element.text = element.text
     for child in element.iterchildren():
         if child.tag == 'p':
             if len(new_element) > 0 or new_element.text:

--- a/trafilatura/xml.py
+++ b/trafilatura/xml.py
@@ -143,12 +143,11 @@ def check_tei(xmldoc, url):
     '''Check if the resulting XML file is conform and scrub remaining tags'''
     # convert head tags
     for elem in xmldoc.iter('head'):
+        elem.tag = 'fw'
+        elem.set('type', 'header')
         if len(elem) > 0:
             new_elem = _tei_handle_complex_head(elem)
             elem.getparent().replace(elem, new_elem)
-        else:
-            elem.tag = 'fw'
-            elem.set('type', 'header')
     # look for elements that are not valid
     for element in xmldoc.findall('.//text/body//*'):
         # check elements
@@ -400,11 +399,10 @@ def write_fullheader(teidoc, docmeta):
 
 def _tei_handle_complex_head(element):
     new_element = Element('ab', attrib=element.attrib)
-    new_element.set("type", "header")
     for child in element.iterchildren():
         if child.tag == 'p':
             if len(new_element) > 0 or new_element.text:
-                # add <lb> if new_element has no children or last tail contains text
+                # add <lb> if <ab> has no children or last tail contains text
                 if len(new_element) == 0 or new_element[-1].tail:
                     SubElement(new_element, 'lb')
                 new_element[-1].tail = child.text


### PR DESCRIPTION
Changes:
- Handling of  `<head>` elements with children in `check_tei` function: if the `<head>` contains children, a new element with tag "ab" is constructed. Any child of `<head>` with tag "p" is removed and the text content added as tail of the previous child. If this tail is already set, a new `<lb>` element is added.

 In the current transformation to TEI,  the tag `<head>` is converted to `<fw>`. In some (probably rare cases), the `<head>` element also contains children. However, in TEI P5, it is not valid for `<fw>` to have certain subelements (e.g. `<p>`, `<list>`) . I'd suggest using `<ab>` instead of `<fw>` because it can handle more elements that might appear as children.
Unfortunately, `<ab>` also shouldn't contain any `<p>`, so in the new transformation a `<lb/>` is added if necessary.


