### PR TITLE
TEI output: handle tail of certain elements

### DIFF
--- a/tests/xml_tei_tests.py
+++ b/tests/xml_tei_tests.py
@@ -90,6 +90,10 @@ def test_tail_on_p_like_elements_removed():
     cleaned = check_tei(xml_doc, "fake_url")
     result = [(elem.tag, elem.text, elem.tail) for elem in cleaned.find(".//div").iterdescendants()]
     assert result == [("ab", "title", None), ("p", "tail", None), ("p", "more text", None)]
+    xml_doc = fromstring("<TEI><text><body><div><p>text</p><lb/>tail</div></body></text></TEI>")
+    cleaned = check_tei(xml_doc, "fake_url")
+    result = [(elem.tag, elem.text, elem.tail) for elem in cleaned.find(".//div").iterdescendants()]
+    assert result == [("p", "text", None), ("p", "tail", None)]
 
 
 if __name__ == "__main__":

--- a/tests/xml_tei_tests.py
+++ b/tests/xml_tei_tests.py
@@ -94,6 +94,10 @@ def test_tail_on_p_like_elements_removed():
     cleaned = check_tei(xml_doc, "fake_url")
     result = [(elem.tag, elem.text, elem.tail) for elem in cleaned.find(".//div").iterdescendants()]
     assert result == [("p", "text", None), ("p", "tail", None)]
+    xml_doc = fromstring("<TEI><text><body><div><p/>tail</div></body></text></TEI>")
+    cleaned = check_tei(xml_doc, "fake_url")
+    result = [(elem.tag, elem.text, elem.tail) for elem in cleaned.find(".//p").iter()]
+    assert result == [("p", "tail", None)]
 
 
 if __name__ == "__main__":

--- a/trafilatura/xml.py
+++ b/trafilatura/xml.py
@@ -148,17 +148,7 @@ def check_tei(xmldoc, url):
     # look for elements that are not valid
     for element in xmldoc.findall('.//text/body//*'):
         if element.tag in {"ab", "fw", "p"} and element.tail and element.tail.strip():
-            if element.tag == 'p':
-                if element.text:
-                    element.text += ' ' + element.tail.strip()
-                else:
-                    element.text = element.tail
-            else:
-                new_sibling = Element('p')
-                new_sibling.text = element.tail.strip()
-                parent = element.getparent()
-                parent.insert(parent.index(element) + 1 , new_sibling)
-            element.tail = None
+            _handle_unwanted_tails(element)
         if element.tag == 'lb' and element.getparent().tag == 'div':
             element.tag = 'p'
             element.text = element.tail
@@ -408,3 +398,18 @@ def write_fullheader(teidoc, docmeta):
     label.text = 'Trafilatura'
     pointer = SubElement(application, 'ptr', target='https://github.com/adbar/trafilatura')
     return header
+
+
+def _handle_unwanted_tails(element):
+    "Handle tail on p, fw and ab elements"
+    if element.tag == 'p':
+        if element.text:
+            element.text += ' ' + element.tail.strip()
+        else:
+            element.text = element.tail
+    else:
+        new_sibling = Element('p')
+        new_sibling.text = element.tail.strip()
+        parent = element.getparent()
+        parent.insert(parent.index(element) + 1 , new_sibling)
+    element.tail = None

--- a/trafilatura/xml.py
+++ b/trafilatura/xml.py
@@ -149,7 +149,10 @@ def check_tei(xmldoc, url):
     for element in xmldoc.findall('.//text/body//*'):
         if element.tag in {"ab", "fw", "p"} and element.tail and element.tail.strip():
             if element.tag == 'p':
-                element.text += ' ' + element.tail.strip()
+                if element.text:
+                    element.text += ' ' + element.tail.strip()
+                else:
+                    element.text = element.tail
             else:
                 new_sibling = Element('p')
                 new_sibling.text = element.tail.strip()

--- a/trafilatura/xml.py
+++ b/trafilatura/xml.py
@@ -24,7 +24,7 @@ from .utils import sanitize
 LOGGER = logging.getLogger(__name__)
 # validation
 TEI_SCHEMA = str(Path(__file__).parent / 'data/tei-schema-pickle.lzma')
-TEI_VALID_TAGS = {'body', 'cell', 'code', 'del', 'div', 'fw', 'graphic', 'head', 'hi', \
+TEI_VALID_TAGS = {'ab', 'body', 'cell', 'code', 'del', 'div', 'fw', 'graphic', 'head', 'hi', \
                   'item', 'lb', 'list', 'p', 'quote', 'ref', 'row', 'table'}
 TEI_VALID_ATTRS = {'rend', 'rendition', 'role', 'target', 'type'}
 TEI_RELAXNG = None  # to be downloaded later if necessary
@@ -147,6 +147,15 @@ def check_tei(xmldoc, url):
         elem.set('type', 'header')
     # look for elements that are not valid
     for element in xmldoc.findall('.//text/body//*'):
+        if element.tag in {"ab", "fw", "p"} and element.tail and element.tail.strip():
+            if element.tag == 'p':
+                element.text += ' ' + element.tail.strip()
+            else:
+                new_sibling = Element('p')
+                new_sibling.text = element.tail.strip()
+                parent = element.getparent()
+                parent.insert(parent.index(element) + 1 , new_sibling)
+            element.tail = None
         # check elements
         if element.tag not in TEI_VALID_TAGS:
             # disable warnings for chosen categories

--- a/trafilatura/xml.py
+++ b/trafilatura/xml.py
@@ -156,6 +156,10 @@ def check_tei(xmldoc, url):
                 parent = element.getparent()
                 parent.insert(parent.index(element) + 1 , new_sibling)
             element.tail = None
+        if element.tag == 'lb' and element.getparent().tag == 'div':
+            element.tag = 'p'
+            element.text = element.tail
+            element.tail = None
         # check elements
         if element.tag not in TEI_VALID_TAGS:
             # disable warnings for chosen categories


### PR DESCRIPTION
Changes: 
- I added some code to clean the TEI output and remove tails on `<p>`, `<fw>`, `<ab>` and `<lb/>`
   - for `<p>` elements: if they have a tail, the tail is merged with the text content
   - for `<fw>` and `<ab>`, a new `<p>` sibling is added and the former tail added as its text
   - `<lb/>` that are direct children of `<div>` are converted to a `<p>` and the tail is added as text
 
Background:
Tail on elements like `<p>` and `<fw>` usually results in a validation error with TEI P5. The same is true for `<lb/>` that have `<div>` as parent.