### PR TITLE
TEI: Handle invalid siblings of <div>

### DIFF
--- a/tests/xml_tei_tests.py
+++ b/tests/xml_tei_tests.py
@@ -141,6 +141,9 @@ def test_unwanted_siblings_of_div_removed():
     result_str = tostring(cleaned.find(".//body"), encoding="unicode")
     expected_str = "<body><div><div><p>text1</p></div><div><list/></div></div></body>"
     assert result_str == expected_str
+    xml_str = "<TEI><text><body><div><p/><div/></div></body></text></TEI>"
+    result = tostring(check_tei(fromstring(xml_str), "fake_url"), encoding="unicode")
+    assert result == xml_str
 
 
 if __name__ == "__main__":

--- a/tests/xml_tei_tests.py
+++ b/tests/xml_tei_tests.py
@@ -131,6 +131,16 @@ def test_unwanted_siblings_of_div_removed():
     cleaned = check_tei(xml_doc, "fake_url")
     result = [elem.tag for elem in cleaned.find(".//div").iter()]
     assert result == ["div", "div", "fw"]
+    xml_doc = fromstring("<TEI><text><body><div><div><p>text1</p></div><list/><ul><li>text2</li></ul></div></body></text></TEI>")
+    cleaned = check_tei(xml_doc, "fake_url")
+    result_str = tostring(cleaned.find(".//body"), encoding="unicode")
+    expected_str = "<body><div><div><p>text1</p></div><div><list/></div></div></body>"
+    assert result_str == expected_str
+    xml_doc = fromstring("<TEI><text><body><div><div><p>text1</p></div><ul><li>text2</li></ul><list/></div></body></text></TEI>")
+    cleaned = check_tei(xml_doc, "fake_url")
+    result_str = tostring(cleaned.find(".//body"), encoding="unicode")
+    expected_str = "<body><div><div><p>text1</p></div><div><list/></div></div></body>"
+    assert result_str == expected_str
 
 
 if __name__ == "__main__":

--- a/tests/xml_tei_tests.py
+++ b/tests/xml_tei_tests.py
@@ -108,10 +108,10 @@ def test_unwanted_siblings_of_div_removed():
     result = [elem.tag for elem in cleaned.find(".//div").iter()]
     expected = ["div", "p", "div", "div", "p", "div", "div", "list"]
     assert result == expected
-    xml_doc = fromstring("<TEI><text><body><div><p/><div/><p>text1</p><fw/><p>text2</p></div></body></text></TEI>")
+    xml_doc = fromstring("<TEI><text><body><div><p/><div/><p>text1</p><ab/><p>text2</p></div></body></text></TEI>")
     cleaned = check_tei(xml_doc, "fake_url")
     result_str = tostring(cleaned.find(".//body"), encoding="unicode")
-    expected_str = "<body><div><p/><div/><div><p>text1</p></div><fw/><div><p>text2</p></div></div></body>"
+    expected_str = "<body><div><p/><div/><div><p>text1</p><ab/><p>text2</p></div></div></body>"
     assert result_str == expected_str
     xml_doc = fromstring("<TEI><text><body><div><div/><ab/></div></body></text></TEI>")
     cleaned = check_tei(xml_doc, "fake_url")
@@ -127,10 +127,10 @@ def test_unwanted_siblings_of_div_removed():
     cleaned = check_tei(xml_doc, "fake_url")
     result = [elem.tag for elem in cleaned.find(".//div").iter()]
     assert result == ["div", "div", "lb"]
-    xml_doc = fromstring("<TEI><text><body><div><div/><fw/></div></body></text></TEI>")
+    xml_doc = fromstring("<TEI><text><body><div><div/><ab/></div></body></text></TEI>")
     cleaned = check_tei(xml_doc, "fake_url")
     result = [elem.tag for elem in cleaned.find(".//div").iter()]
-    assert result == ["div", "div", "fw"]
+    assert result == ["div", "div", "div", "ab"]
     xml_doc = fromstring("<TEI><text><body><div><div><p>text1</p></div><list/><ul><li>text2</li></ul></div></body></text></TEI>")
     cleaned = check_tei(xml_doc, "fake_url")
     result_str = tostring(cleaned.find(".//body"), encoding="unicode")

--- a/tests/xml_tei_tests.py
+++ b/tests/xml_tei_tests.py
@@ -108,6 +108,11 @@ def test_unwanted_siblings_of_div_removed():
     result = [elem.tag for elem in cleaned.find(".//div").iter()]
     expected = ["div", "p", "div", "div", "p", "div", "div", "list"]
     assert result == expected
+    xml_doc = fromstring("<TEI><text><body><div><p/><div/><p>text1</p><fw/><p>text2</p></div></body></text></TEI>")
+    cleaned = check_tei(xml_doc, "fake_url")
+    result_str = tostring(cleaned.find(".//body"), encoding="unicode")
+    expected_str = "<body><div><p/><div/><div><p>text1</p></div><fw/><div><p>text2</p></div></div></body>"
+    assert result_str == expected_str
 
 
 if __name__ == "__main__":

--- a/tests/xml_tei_tests.py
+++ b/tests/xml_tei_tests.py
@@ -113,6 +113,24 @@ def test_unwanted_siblings_of_div_removed():
     result_str = tostring(cleaned.find(".//body"), encoding="unicode")
     expected_str = "<body><div><p/><div/><div><p>text1</p></div><fw/><div><p>text2</p></div></div></body>"
     assert result_str == expected_str
+    xml_doc = fromstring("<TEI><text><body><div><div/><ab/></div></body></text></TEI>")
+    cleaned = check_tei(xml_doc, "fake_url")
+    result_str = tostring(cleaned.find(".//body"), encoding="unicode")
+    expected_str = "<body><div><div/><div><ab/></div></div></body>"
+    assert result_str == expected_str
+    xml_doc = fromstring("<TEI><text><body><div><div/><quote>text</quote></div></body></text></TEI>")
+    cleaned = check_tei(xml_doc, "fake_url")
+    result = [elem.tag for elem in cleaned.find(".//div").iter()]
+    expected = ["div", "div", "div", "quote"]
+    assert result == expected
+    xml_doc = fromstring("<TEI><text><body><div><div/><lb/></div></body></text></TEI>")
+    cleaned = check_tei(xml_doc, "fake_url")
+    result = [elem.tag for elem in cleaned.find(".//div").iter()]
+    assert result == ["div", "div", "lb"]
+    xml_doc = fromstring("<TEI><text><body><div><div/><fw/></div></body></text></TEI>")
+    cleaned = check_tei(xml_doc, "fake_url")
+    result = [elem.tag for elem in cleaned.find(".//div").iter()]
+    assert result == ["div", "div", "fw"]
 
 
 if __name__ == "__main__":

--- a/tests/xml_tei_tests.py
+++ b/tests/xml_tei_tests.py
@@ -144,6 +144,10 @@ def test_unwanted_siblings_of_div_removed():
     xml_str = "<TEI><text><body><div><p/><div/></div></body></text></TEI>"
     result = tostring(check_tei(fromstring(xml_str), "fake_url"), encoding="unicode")
     assert result == xml_str
+    xml_doc = fromstring("<TEI><text><body><div><div/><lb/>tail</div></body></text></TEI>")
+    cleaned = check_tei(xml_doc, "fake_url")
+    result = [elem.tag for elem in cleaned.find(".//div").iter()]
+    assert result == ["div", "div", "div", "p"]
 
 
 def test_tail_on_p_like_elements_removed():

--- a/trafilatura/xml.py
+++ b/trafilatura/xml.py
@@ -24,7 +24,7 @@ from .utils import sanitize
 LOGGER = logging.getLogger(__name__)
 # validation
 TEI_SCHEMA = str(Path(__file__).parent / 'data/tei-schema-pickle.lzma')
-TEI_VALID_TAGS = {'body', 'cell', 'code', 'del', 'div', 'fw', 'graphic', 'head', 'hi', \
+TEI_VALID_TAGS = {'ab', 'body', 'cell', 'code', 'del', 'div', 'fw', 'graphic', 'head', 'hi', \
                   'item', 'lb', 'list', 'p', 'quote', 'ref', 'row', 'table'}
 TEI_VALID_ATTRS = {'rend', 'rendition', 'role', 'target', 'type'}
 TEI_RELAXNG = None  # to be downloaded later if necessary
@@ -166,7 +166,7 @@ def check_tei(xmldoc, url):
         for sibling in div_elem.itersiblings():
             if sibling.tag == "div":
                 break
-            if sibling.tag in {"p", "list", "table"}:
+            if sibling.tag in {"p", "list", "table", "quote", "ab"}:
                 if new_sibling_index is None:
                     new_sibling_index = parent.index(sibling)
                 new_sibling.append(sibling)

--- a/trafilatura/xml.py
+++ b/trafilatura/xml.py
@@ -170,6 +170,11 @@ def check_tei(xmldoc, url):
                 if new_sibling_index is None:
                     new_sibling_index = parent.index(sibling)
                 new_sibling.append(sibling)
+            else:
+                if new_sibling_index is not None and len(new_sibling) != 0:
+                    parent.insert(new_sibling_index, new_sibling)
+                    new_sibling = Element("div")
+                    new_sibling_index = None
         if new_sibling_index is not None and len(new_sibling) != 0:
             parent.insert(new_sibling_index, new_sibling)
     # export metadata

--- a/trafilatura/xml.py
+++ b/trafilatura/xml.py
@@ -148,14 +148,16 @@ def check_tei(xmldoc, url):
         if len(elem) > 0:
             new_elem = _tei_handle_complex_head(elem)
             elem.getparent().replace(elem, new_elem)
+    # convert <lb/> when child of <div> to <p>
+    for element in xmldoc.findall(".//text/body//div/lb"):
+        if element.tail is not None and element.tail.strip():
+            element.tag = 'p'
+            element.text = element.tail
+            element.tail = None
     # look for elements that are not valid
     for element in xmldoc.findall('.//text/body//*'):
         if element.tag in {"ab", "p"} and element.tail and element.tail.strip():
             _handle_unwanted_tails(element)
-        if element.tag == 'lb' and element.getparent().tag == 'div':
-            element.tag = 'p'
-            element.text = element.tail
-            element.tail = None
         # check elements
         if element.tag not in TEI_VALID_TAGS:
             # disable warnings for chosen categories

--- a/trafilatura/xml.py
+++ b/trafilatura/xml.py
@@ -159,6 +159,19 @@ def check_tei(xmldoc, url):
             if attribute not in TEI_VALID_ATTRS:
                 LOGGER.warning('not a valid TEI attribute, removing: %s in %s %s', attribute, element.tag, url)
                 element.attrib.pop(attribute)
+    for div_elem in xmldoc.findall(".//text/body//div"):
+        new_sibling = Element("div")
+        new_sibling_index = None
+        parent = div_elem.getparent()
+        for sibling in div_elem.itersiblings():
+            if sibling.tag == "div":
+                break
+            if sibling.tag in {"p", "list", "table"}:
+                if new_sibling_index is None:
+                    new_sibling_index = parent.index(sibling)
+                new_sibling.append(sibling)
+        if new_sibling_index is not None and len(new_sibling) != 0:
+            parent.insert(new_sibling_index, new_sibling)
     # export metadata
     #metadata = (title + '\t' + date + '\t' + uniqueid + '\t' + url + '\t').encode('utf-8')
     return xmldoc

--- a/trafilatura/xml.py
+++ b/trafilatura/xml.py
@@ -154,13 +154,13 @@ def check_tei(xmldoc, url):
             LOGGER.warning('not a TEI element, removing: %s %s', element.tag, url)
             merge_with_parent(element)
             continue
+        if element.tag == "div":
+            _wrap_unwanted_siblings_of_div(element)
         # check attributes
         for attribute in element.attrib:
             if attribute not in TEI_VALID_ATTRS:
                 LOGGER.warning('not a valid TEI attribute, removing: %s in %s %s', attribute, element.tag, url)
                 element.attrib.pop(attribute)
-    for div_elem in xmldoc.findall(".//text/body//div"):
-        _wrap_unwanted_siblings_of_div(div_elem)
     # export metadata
     #metadata = (title + '\t' + date + '\t' + uniqueid + '\t' + url + '\t').encode('utf-8')
     return xmldoc


### PR DESCRIPTION
Changes:
- I added a check to the `check_tei` function to search siblings of `<div/>` elements for unallowed tags. If such tags (e.g. `<p/>`) appear, these elements are wrapped in an additional `<div/>` element. 

In TEI P5, some elements (e.g. `<p/>, <table/>, <list/>, <quote/>, <ab/>`) can appear as sibling *before* a `<div/>` element but not after. 