### PR TITLE
TEI: remove text from <div> elements

### DIFF
--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -648,6 +648,21 @@ def test_tei():
     assert xml.write_fullheader(header, docmeta) is not None
     docmeta.title, docmeta.sitename = None, None
     assert xml.write_fullheader(header, docmeta) is not None
+    xml_doc = etree.fromstring("<TEI><text><body><div>text</div></body></text></TEI>")
+    cleaned = xml.check_tei(xml_doc, "fake_url")
+    result = [(elem.tag, elem.text) for elem in cleaned.find(".//div").iter()]
+    expected = [("div", None), ("p", "text")]
+    assert result == expected
+    xml_doc = etree.fromstring("<TEI><text><body><div><div>text1<p>text2</p></div></div></body></text></TEI>")
+    cleaned = xml.check_tei(xml_doc, "fake_url")
+    result = [(elem.tag, elem.text) for elem in cleaned.find(".//div").iter()]
+    expected = [("div", None), ("div", None), ("p", "text1 text2")]
+    assert result == expected
+    xml_doc = etree.fromstring("<TEI><text><body><div><div>text1<head>text2</head></div></div></body></text></TEI>")
+    cleaned = xml.check_tei(xml_doc, "fake_url")
+    result = [(elem.tag, elem.text) for elem in cleaned.find(".//div").iter()]
+    expected = [("div", None), ("div", None), ("p", "text1"), ("fw", "text2")]
+    assert result == expected
 
 
 def test_htmlprocessing():

--- a/trafilatura/xml.py
+++ b/trafilatura/xml.py
@@ -154,6 +154,15 @@ def check_tei(xmldoc, url):
             LOGGER.warning('not a TEI element, removing: %s %s', element.tag, url)
             merge_with_parent(element)
             continue
+        if element.tag == "div":
+            if element.text is not None and element.text.strip():
+                if element.getchildren() and element[0].tag == 'p':
+                    element[0].text = ' '.join([element.text, element[0].text])
+                else:
+                    new_child = Element("p")
+                    new_child.text = element.text
+                    element.insert(0, new_child)
+                element.text = None
         # check attributes
         for attribute in element.attrib:
             if attribute not in TEI_VALID_ATTRS:


### PR DESCRIPTION
In TEI P5, `<div/>` elements shouldn't have text content. I added a check to find `<div/>`  elements with text. 
If such text occurs, it is either added to a new `<p/>` Element that is added as the first child of the `<div/>` or, if the first child already is a `<p/>` element, the text from the `<div/>` is joined with its text.  