### PR TITLE
Changed markdown formatting of headers from = to #

### DIFF
--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -292,7 +292,7 @@ def test_formatting():
     # titles as markdown
     my_document = html.fromstring('<html><body><article><h3>Title</h3><p><b>This here is in bold font.</b></p></article></body></html>')
     my_result = extract(my_document, output_format='txt', include_formatting=True, config=ZERO_CONFIG)
-    assert my_result == '=== Title ===\n**This here is in bold font.**'
+    assert my_result == '### Title\n**This here is in bold font.**'
     # nested
     my_document = html.fromstring('<html><body><p><b>This here is in bold and <i>italic</i> font.</b></p></body></html>')
     my_result = extract(my_document, output_format='xml', include_formatting=True, config=ZERO_CONFIG)

--- a/trafilatura/xml.py
+++ b/trafilatura/xml.py
@@ -203,7 +203,7 @@ def replace_element_text(element, include_formatting):
                     number = int(element.get('rend')[1])
                 except (TypeError, ValueError):
                     number = 2
-                element.text = ''.join(['='*number, ' ', element.text, ' ', '='*number])
+                element.text = ''.join(['#'*number, ' ', element.text])
             elif element.tag == 'del':
                 element.text = ''.join(['~~', element.text, '~~'])
         elif element.tag == 'hi':


### PR DESCRIPTION
E.g.

XML: 

    <head rend="h2">Title</head>

Markdown:

    ## Title

(where it used to be that markdown was `== Title ==`)