### PR TITLE
TEI: Nesting of <ab> elements

### DIFF
--- a/tests/xml_tei_tests.py
+++ b/tests/xml_tei_tests.py
@@ -179,6 +179,10 @@ def test_tail_on_p_like_elements_removed():
     cleaned = check_tei(xml_doc, "fake_url")
     result = [(elem.tag, elem.text, elem.tail) for elem in cleaned.find(".//p").iter()]
     assert result == [("p", "tail", None)]
+    xml_doc = fromstring("<TEI><text><body><div><p/>tail1<ab/>tail2<ab/>tail3</div></body></text></TEI>")
+    cleaned = check_tei(xml_doc, "fake_url")
+    result = [elem.text for elem in cleaned.iter() if elem.text]
+    assert result == ["tail1", "tail2", "tail3"]
 
 
 def test_head_with_children_converted_to_ab():
@@ -256,7 +260,16 @@ def test_head_with_children_converted_to_ab():
     cleaned = check_tei(xml_doc, "fake_url")
     result = [(child.tag, child.text, child.tail) for child in cleaned.find(".//ab").iter()]
     assert result == [("ab", "text1", None), ("lb", None, "text2")]
-    # check that parent of <ab> is not <p>
+    xml_doc = fromstring("<TEI><text><body><head><list><item>text1</item></list><p>text2</p></head>tail</body></text></TEI>")
+    cleaned = check_tei(xml_doc, "fake_url")
+    result = [(child.tag, child.text, child.tail) for child in cleaned.find(".//body").iter()]
+    assert result == [
+        ("body", None, None),
+        ("ab", None, None),
+        ("list", None, "text2"),
+        ("item", "text1", None),
+        ("p", "tail", None)
+    ]
     xml_doc = fromstring("<text><p><head>text1</head></p></text>")
     cleaned = check_tei(xml_doc, "fake_url")
     assert cleaned.find(".//ab") is not None and cleaned.find(".//p") is None

--- a/tests/xml_tei_tests.py
+++ b/tests/xml_tei_tests.py
@@ -303,9 +303,9 @@ def test_ab_with_p_parent_resolved():
     xml_doc = fromstring("<TEI><text><body><p>text0<head>text1</head>text2</p></body></text></TEI>")
     cleaned = check_tei(xml_doc, "fake_url")
     assert cleaned.find(".//ab").getnext().text == "text2"
-    xml_doc = fromstring("<TEI><text><body><p>text0<head>text1</head>text2</p></body></text></TEI>")
+    xml_doc = fromstring("<TEI><text><body><p>text0<list/><head>text1</head>text2</p>text3</body></text></TEI>")
     cleaned = check_tei(xml_doc, "fake_url")
-    assert "text2" in tostring(cleaned, encoding="unicode")
+    assert "text2" in tostring(cleaned, encoding="unicode") and cleaned.find(".//p/list") is not None
     xml_doc = fromstring("""
     <TEI>
       <text><body>
@@ -355,13 +355,14 @@ def test_ab_with_p_parent_resolved():
         ("ab", "text1", None),
         ("p", "text2", None),
     ]
-    xml_doc = fromstring("<TEI><text><body><p>text1<head>text2</head>text3</p></body></text></TEI>")
+    xml_doc = fromstring("<TEI><text><body><p>text1<head>text2</head>text3<head>text4</head></p></body></text></TEI>")
     cleaned = check_tei(xml_doc, "fake_url")
     result = [(elem.tag, elem.text, elem.tail) for elem in cleaned.iter(["p", "ab"])]
     assert result == [
         ("p", "text1", None),
         ("ab", "text2", None),
         ("p", "text3", None),
+        ("ab", "text4", None),
     ]
     xml_doc = fromstring("<text><head>text1</head><p>text2<head>text3</head></p></text>")
     cleaned = check_tei(xml_doc, "fake_url")

--- a/tests/xml_tei_tests.py
+++ b/tests/xml_tei_tests.py
@@ -1,7 +1,7 @@
 """
 Test for transformation to TEI.
 """
-from lxml.etree import Element, fromstring, tostring
+from lxml.etree import Element, fromstring, tostring, XMLParser
 
 from trafilatura.metadata import Document
 from trafilatura.xml import check_tei, write_fullheader
@@ -182,6 +182,7 @@ def test_tail_on_p_like_elements_removed():
 
 
 def test_head_with_children_converted_to_ab():
+    parser = XMLParser(remove_blank_text=True)
     xml_doc = fromstring("<text><head>heading</head><p>some text</p></text>")
     cleaned = check_tei(xml_doc, "fake_url")
     result = [
@@ -255,6 +256,156 @@ def test_head_with_children_converted_to_ab():
     cleaned = check_tei(xml_doc, "fake_url")
     result = [(child.tag, child.text, child.tail) for child in cleaned.find(".//ab").iter()]
     assert result == [("ab", "text1", None), ("lb", None, "text2")]
+    # check that parent of <ab> is not <p>
+    xml_doc = fromstring("<text><p><head>text1</head></p></text>")
+    cleaned = check_tei(xml_doc, "fake_url")
+    assert cleaned.find(".//ab") is not None and cleaned.find(".//p") is None
+    xml_doc = fromstring("<body><p>text1<head>text2</head></p></body>")
+    cleaned = check_tei(xml_doc, "fake_url")
+    result = cleaned.find(".//ab")
+    assert result.getparent().tag == "body" and result.text == "text2"
+    xml_doc = fromstring("<TEI><text><body><p><head>text1</head></p>text2</body></text></TEI>")
+    cleaned = check_tei(xml_doc, "fake_url")
+    assert cleaned.find(".//ab").text == "text1" and cleaned.find(".//p").text == "text2"
+    xml_doc = fromstring("<text><p><head rend='h3'>text</head></p></text>")
+    cleaned = check_tei(xml_doc, "fake_url")
+    assert cleaned.find("ab").attrib == {"type":"header", "rend":"h3"}
+    xml_doc = fromstring("<text><p><head>text1</head><list/><head>text2</head></p></text>")
+    cleaned = check_tei(xml_doc, "fake_url")
+    result = [(elem.tag, elem.text, elem.tail) for elem in cleaned.iter()]
+    assert result == [
+        ("text", None, None),
+        ("ab", "text1", None),
+        ("p", None, None),
+        ("list", None, None),
+        ("ab", "text2", None),
+
+    ]
+    xml_doc = fromstring("<TEI><text><body><p><head>text1</head>text2</p></body></text></TEI>")
+    cleaned = check_tei(xml_doc, "fake_url")
+    assert cleaned.find(".//p").text == "text2"
+    xml_doc = fromstring("<TEI><text><body><p>text0<head>text1</head>text2</p></body></text></TEI>")
+    cleaned = check_tei(xml_doc, "fake_url")
+    assert cleaned.find(".//ab").getnext().text == "text2"
+    xml_doc = fromstring("<TEI><text><body><p>text0<head>text1</head>text2</p></body></text></TEI>")
+    cleaned = check_tei(xml_doc, "fake_url")
+    assert "text2" in tostring(cleaned, encoding="unicode")
+    xml_doc = fromstring("""
+    <TEI>
+      <text><body>
+        <p>text1<head>text2</head>text3
+          <head>text4</head>text5
+        </p>
+      </body></text>
+    </TEI>"""
+    )
+    cleaned = check_tei(xml_doc, "fake_url")
+    result = [(elem.tag, elem.text, elem.tail) for elem in xml_doc.iter(["p", "ab"])]
+    assert result == [
+        ("p", "text1", None),
+        ("ab", "text2", None),
+        ("p", "text3", None),
+        ("ab", "text4", None),
+        ("p", "text5", None),
+    ]
+    xml_doc = fromstring("""
+    <TEI>
+      <text>
+        <body>
+          <p>text0<head>text1</head>
+            <list>
+              <item>text2</item>
+            </list>
+            <head>text3</head>text4
+          </p>
+        </body>
+      </text>
+    </TEI>"""
+    )
+    cleaned = check_tei(xml_doc, "fake_url")
+    result = [(elem.tag, elem.text, elem.tail) for elem in xml_doc.iter(["p", "ab"])]
+    assert result == [
+        ("p", "text0", None),
+        ("ab", "text1", None),
+        ("p", None, None),
+        ("ab", "text3", None),
+        ("p", "text4", None),
+    ]
+    xml_doc = fromstring("<TEI><text><body><p>text0<head>text1</head></p>text2</body></text></TEI>")
+    cleaned = check_tei(xml_doc, "fake_url")
+    result = [(elem.tag, elem.text, elem.tail) for elem in xml_doc.iter(["p", "ab"])]
+    assert result == [
+        ("p", "text0", None),
+        ("ab", "text1", None),
+        ("p", "text2", None),
+    ]
+    xml_doc = fromstring("<TEI><text><body><p>text1<head>text2</head>text3</p></body></text></TEI>")
+    cleaned = check_tei(xml_doc, "fake_url")
+    result = [(elem.tag, elem.text, elem.tail) for elem in cleaned.iter(["p", "ab"])]
+    assert result == [
+        ("p", "text1", None),
+        ("ab", "text2", None),
+        ("p", "text3", None),
+    ]
+    xml_doc = fromstring("<text><head>text1</head><p>text2<head>text3</head></p></text>")
+    cleaned = check_tei(xml_doc, "fake_url")
+    result = [(elem.tag, elem.text, elem.tail) for elem in cleaned]
+    assert [
+        ("ab", "text1", None),
+        ("p", "text2", None),
+        ("ab", "text3", None),
+    ]
+    xml_doc = fromstring("<text><p>text1<head>text2</head></p><head>text3</head></text>")
+    cleaned = check_tei(xml_doc, "fake_url")
+    result = [(elem.tag, elem.text, elem.tail) for elem in cleaned]
+    assert result == [
+        ("p", "text1", None),
+        ("ab", "text2", None),
+        ("ab", "text3", None),
+    ]
+    xml_doc = fromstring(
+        """
+        <text>
+            <head>text1<p>text2</p></head>
+            <p>text3<head>text4</head></p>
+        </text>""",
+        parser=parser
+    )
+    cleaned = check_tei(xml_doc, "fake_url")
+    result = [(elem.tag, elem.text, elem.tail) for elem in cleaned.iter()]
+    assert result == [
+        ("text", None, None),
+        ("ab", "text1", None),
+        ("lb", None, "text2"),
+        ("p", "text3", None),
+        ("ab", "text4", None),
+    ]
+    xml_doc = fromstring(
+        """
+        <TEI>
+        <text>
+          <body>
+            <p>text1<head>
+                    <list>
+                        <item>text2</item>
+                    </list>
+                </head>
+            text3
+            </p>
+          </body>
+        </text>
+        </TEI>
+        """,
+        parser=parser
+    )
+    cleaned = check_tei(xml_doc, "fake_url")
+    result = [(elem.tag, elem.text, elem.tail) for elem in cleaned.iter(["p", "ab", "item"])]
+    assert result ==  [
+        ("p", "text1", None),
+        ("ab", None, None),
+        ("item", "text2", None),
+        ("p", "text3", None),
+    ]
 
 
 if __name__ == "__main__":

--- a/tests/xml_tei_tests.py
+++ b/tests/xml_tei_tests.py
@@ -186,7 +186,6 @@ def test_tail_on_p_like_elements_removed():
 
 
 def test_head_with_children_converted_to_ab():
-    parser = XMLParser(remove_blank_text=True)
     xml_doc = fromstring("<text><head>heading</head><p>some text</p></text>")
     cleaned = check_tei(xml_doc, "fake_url")
     result = [
@@ -270,6 +269,10 @@ def test_head_with_children_converted_to_ab():
         ("item", "text1", None),
         ("p", "tail", None)
     ]
+
+
+def test_ab_with_p_parent_resolved():
+    parser = XMLParser(remove_blank_text=True)
     xml_doc = fromstring("<text><p><head>text1</head></p></text>")
     cleaned = check_tei(xml_doc, "fake_url")
     assert cleaned.find(".//ab") is not None and cleaned.find(".//p") is None
@@ -426,3 +429,4 @@ if __name__ == "__main__":
     test_unwanted_siblings_of_div_removed()
     test_tail_on_p_like_elements_removed()
     test_head_with_children_converted_to_ab()
+    test_ab_with_p_parent_resolved()

--- a/trafilatura/xml.py
+++ b/trafilatura/xml.py
@@ -473,6 +473,8 @@ def _tei_handle_complex_head(element):
                 new_element.text = child.text
         else:
             new_element.append(child)
+    if element.tail is not None and element.tail.strip():
+        new_element.tail = element.tail.strip()
     return new_element
 
 

--- a/trafilatura/xml.py
+++ b/trafilatura/xml.py
@@ -160,9 +160,13 @@ def check_tei(xmldoc, url):
     for elem in xmldoc.iter('head'):
         elem.tag = 'ab'
         elem.set('type', 'header')
+        parent = elem.getparent()
         if len(elem) > 0:
             new_elem = _tei_handle_complex_head(elem)
-            elem.getparent().replace(elem, new_elem)
+            parent.replace(elem, new_elem)
+            elem = new_elem
+        if parent.tag == "p":
+            _move_element_one_level_up(elem)
     # convert <lb/> when child of <div> to <p>
     for element in xmldoc.findall(".//text/body//div/lb"):
         if element.tail is not None and element.tail.strip():
@@ -493,3 +497,18 @@ def _wrap_unwanted_siblings_of_div(div_element):
                 new_sibling_index = None
     if new_sibling_index is not None and len(new_sibling) != 0:
         parent.insert(new_sibling_index, new_sibling)
+
+
+def _move_element_one_level_up(element):
+    parent = element.getparent()
+    new_elem = Element("p")
+    for sibling in element.itersiblings():
+        new_elem.append(sibling)
+    parent.addnext(element)
+    if element.tail is not None and element.tail.strip():
+        new_elem.text = element.tail.strip()
+        element.tail = None
+    if len(new_elem) != 0 or new_elem.text:
+        element.addnext(new_elem)
+    if len(parent) == 0 and parent.text is None:
+        parent.getparent().remove(parent)


### PR DESCRIPTION
Changes:
- I added a check to convert `<ab>` elements that are children of `<p>` to their siblings
- In the "_handle_complex_head" function, I added some code to preserve the tail of the `<ab>` element