### PR TITLE
Add new class to metadata title

### DIFF
--- a/tests/metadata_tests.py
+++ b/tests/metadata_tests.py
@@ -28,6 +28,8 @@ def test_titles():
     assert metadata.title == 'First'
     metadata = extract_metadata('<html><body><h1>   </h1><div class="post-title">Test Title</div></body></html>')
     assert metadata.title == 'Test Title'
+    metadata = extract_metadata('<html><body><h2 class="block-title">Main menu</h2><h1 class="article-title">Test Title</h1></body></html>')
+    assert metadata.title == 'Test Title'
     metadata = extract_metadata('<html><body><h2>First</h2><h1>Second</h1></body></html>')
     assert metadata.title == 'Second'
     metadata = extract_metadata('<html><body><h2>First</h2><h2>Second</h2></body></html>')

--- a/trafilatura/metaxpaths.py
+++ b/trafilatura/metaxpaths.py
@@ -52,7 +52,7 @@ tags_xpaths = [
 
 
 title_xpaths = [
-    '//*[(self::h1 or self::h2)][contains(@class, "post-title") or contains(@class, "entry-title") or contains(@class, "headline") or contains(@id, "headline") or contains(@itemprop, "headline") or contains(@class, "post__title")]',
+    '//*[(self::h1 or self::h2)][contains(@class, "post-title") or contains(@class, "entry-title") or contains(@class, "headline") or contains(@id, "headline") or contains(@itemprop, "headline") or contains(@class, "post__title") or contains(@class, "article-title")]',
     '//*[@class="entry-title" or @class="post-title"]',
     '//*[(self::h1 or self::h2 or self::h3)][contains(@class, "title") or contains(@id, "title")]',
 ]

--- a/trafilatura/utils.py
+++ b/trafilatura/utils.py
@@ -52,10 +52,15 @@ AUTHOR_REMOVE_PREPOSITION = re.compile(r'\b\s+(am|on|for|at|in|to|from|of|via|wi
 AUTHOR_EMAIL = re.compile(r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b')
 AUTHOR_SPLIT = re.compile(r'/|;|,|\||&|(?:^|\W)[u|a]nd(?:$|\W)', flags=re.IGNORECASE)
 AUTHOR_EMOJI_REMOVE = re.compile(
-    "["u"\U0001F300-\U0001F6FF" u"\U0001F1E0-\U0001F1FF"
-    u"\U00002702-\U000027B0" u"\U000024C2-\U0001F251"
-    u"\U0001f926-\U0001f937" u"\U00010000-\U0010ffff" u"\u200d"
-    u"\u23cf" u"\u23e9" u"\u231a" u"\ufe0f" u"\u3030" "]+", flags=re.UNICODE)
+    "["
+    u"\U00002700-\U000027BF"  # Dingbats
+    u"\U0001F600-\U0001F64F"  # Emoticons
+    u"\U00002600-\U000026FF"  # Miscellaneous Symbols
+    u"\U0001F300-\U0001F5FF"  # Miscellaneous Symbols And Pictographs
+    u"\U0001F900-\U0001F9FF"  # Supplemental Symbols and Pictographs
+    u"\U0001FA70-\U0001FAFF"  # Symbols and Pictographs Extended-A
+    u"\U0001F680-\U0001F6FF"  # Transport and Map Symbols
+    "]+", flags=re.UNICODE)
 
 CLEAN_META_TAGS = re.compile(r'["\']')
 


### PR DESCRIPTION
Hey @adbar, Happy New Year!

I'm sending this pull request to fix a wrong post title with a class "article-title".

https://bit.ly/3Y87nao

Before:
```
title: "Main menu"
```

After:
```
title: "Repco reinforces its position"
```

Thanks.