### PR TITLE
feat: extract pagetype from og:type or ld+json

### DIFF
--- a/tests/json_metadata_tests.py
+++ b/tests/json_metadata_tests.py
@@ -16,13 +16,16 @@ def test_json_extraction():
     ## JSON extraction
     metadata = extract_metadata('''<html><body><script data-rh="true" type="application/ld+json">{"@context":"http://schema.org","@type":"NewsArticle","description":"The president and his campaign competed again on Monday, with his slash-and-burn remarks swamping news coverage even as his advisers used conventional levers to try to lift his campaign.","image":[{"@context":"http://schema.org","@type":"ImageObject","url":"https://static01.nyt.com/images/2020/10/19/us/politics/19campaign/19campaign-videoSixteenByNineJumbo1600.jpg","height":900,"width":1600,"caption":"In Arizona on Monday, President Trump aired grievances against people including former President Barack Obama and Michelle Obama; Joseph R. Biden Jr. and Hunter Biden; Dr. Anthony S. Fauci; and two female NBC News hosts. "},{"@context":"http://schema.org","@type":"ImageObject","url":"https://static01.nyt.com/images/2020/10/19/us/politics/19campaign/merlin_178764738_11d22ae6-9e7e-4d7a-b28a-20bf52b23e86-superJumbo.jpg","height":1365,"width":2048,"caption":"In Arizona on Monday, President Trump aired grievances against people including former President Barack Obama and Michelle Obama; Joseph R. Biden Jr. and Hunter Biden; Dr. Anthony S. Fauci; and two female NBC News hosts. "},{"@context":"http://schema.org","@type":"ImageObject","url":"https://static01.nyt.com/images/2020/10/19/us/politics/19campaign/19campaign-mediumSquareAt3X.jpg","height":1800,"width":1800,"caption":"In Arizona on Monday, President Trump aired grievances against people including former President Barack Obama and Michelle Obama; Joseph R. Biden Jr. and Hunter Biden; Dr. Anthony S. Fauci; and two female NBC News hosts. "}],"mainEntityOfPage":"https://www.nytimes.com/2020/10/19/us/politics/trump-ads-biden-election.html","url":"https://www.nytimes.com/2020/10/19/us/politics/trump-ads-biden-election.html","inLanguage":"en","author":[{"@context":"http://schema.org","@type":"Person","url":"https://www.nytimes.com/by/maggie-haberman","name":"Maggie Haberman"},{"@context":"http://schema.org","@type":"Person","url":"https://www.nytimes.com/by/shane-goldmacher","name":"Shane Goldmacher"},{"@context":"http://schema.org","@type":"Person","url":"https://www.nytimes.com/by/michael-crowley","name":"Michael Crowley"}],"dateModified":"2020-10-20T01:22:07.000Z","datePublished":"2020-10-19T22:24:02.000Z","headline":"Trump Team Unveils $55 Million Ad Blitz on a Day of Scattershot Attacks","publisher":{"@id":"https://www.nytimes.com/#publisher"},"copyrightHolder":{"@id":"https://www.nytimes.com/#publisher"},"sourceOrganization":{"@id":"https://www.nytimes.com/#publisher"},"copyrightYear":2020,"isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".meteredContent"},"isPartOf":{"@type":["CreativeWork","Product"],"name":"The New York Times","productID":"nytimes.com:basic"}}</script><script data-rh="true" type="application/ld+json">{"@context":"http://schema.org","@type":"NewsMediaOrganization","name":"The New York Times","logo":{"@context":"http://schema.org","@type":"ImageObject","url":"https://static01.nyt.com/images/misc/NYT_logo_rss_250x40.png","height":40,"width":250},"url":"https://www.nytimes.com/","@id":"https://www.nytimes.com/#publisher","diversityPolicy":"https://www.nytco.com/diversity-and-inclusion-at-the-new-york-times/","ethicsPolicy":"https://www.nytco.com/who-we-are/culture/standards-and-ethics/","masthead":"https://www.nytimes.com/interactive/2019/admin/the-new-york-times-masthead.html","foundingDate":"1851-09-18","sameAs":"https://en.wikipedia.org/wiki/The_New_York_Times"}</script><script data-rh="true" type="application/ld+json">{"@context":"http://schema.org","@type":"BreadcrumbList","itemListElement":[{"@context":"http://schema.org","@type":"ListItem","name":"U.S.","position":1,"item":"https://www.nytimes.com/section/us"},{"@context":"http://schema.org","@type":"ListItem","name":"Politics","position":2,"item":"https://www.nytimes.com/section/politics"}]}</script></body></html>''')
     assert metadata.author == 'Maggie Haberman; Shane Goldmacher; Michael Crowley'
+    assert metadata.pagetype == 'newsarticle'
 
     metadata = extract_metadata('''<html><body><script data-rh="true" type="application/ld+json">{"@context":"http://schema.org","@type":"NewsArticle","mainEntityOfPage":{"@type":"WebPage","@id":"https://www.perthnow.com.au/news/government-defends-graphic-covid-19-ad-after-backlash-c-3376985"},"dateline":null,"publisher":{"@type":"Organization","name":"PerthNow","url":"https://www.perthnow.com.au","logo":{"@type":"ImageObject","url":"https://www.perthnow.com.au/static/publisher-logos/publisher-logo-60px-high.png","width":575,"height":60}},"keywords":["News","News","Australia","Politics","Federal Politics","News","TAS News"],"articleSection":"News","headline":"Government defends graphic Covid-19 ad after backlash","description":"A graphic COVID-19 ad showing a young woman apparently on the verge of death has prompted a backlash, but the government insists it wasn’t done lightly.","dateCreated":"2021-07-12T00:11:50.000Z","datePublished":"2021-07-12T00:11:50.000Z","dateModified":"2021-07-12T01:25:20.617Z","isAccessibleForFree":"True","articleBody":"The man tasked with co-ordinating Australia&rsquo;s Covid-19 vaccine rollout insists a confronting ad depicting a woman on the verge of death was not run lightly. The 30-second clip, depicting a woman apparently in her 20s or 30s gasping for air on a hospital bed, was filmed last year, but the federal government held off running it as no outbreak was deemed serious enough to warrant it. The government has been forced to defend the ad, reminiscent of the &ldquo;Grim Reaper&rdquo; HIV ads in the 1980s, after it prompted a backlash over claims it was too confronting. A more temperate series of ads, depicting arms on ordinary Australians with the moniker &ldquo;Arm Yourself&rdquo;, began last week, but Covid-19 taskforce commander Lieutenant General John Frewen said the escalating situation in Sydney called for a more explicit response. &ldquo;It is absolutely confronting and we didn&rsquo;t use it lightly. There was serious consideration given to whether it was required and we took expert advice,&rdquo; he told Today on Monday. &ldquo;It is confronting but leaves people in no doubt about the seriousness of getting Covid, and it seeks to have people stay home, get tested and get vaccinated as quickly as they can.&rdquo; NSW on Sunday confirmed another 77 cases, 31 of which had been in the community while infectious, and Premier Gladys Berejiklian warned she would be &ldquo;shocked&rdquo; if the number did not exceed 100 on Monday. General Frewen said the &ldquo;concerning situation&rdquo; had prompted the government to shift an additional 300,000 doses to NSW over the coming fortnight. &ldquo;The Delta variant is proving to be very difficult to contain, so we&rsquo;re working very closely with NSW authorities and standing ready to help them in any way we can,&rdquo; he said. Agriculture Minister David Littleproud said the ad was designed to shock Sydneysiders into action as the situation deteriorated. &ldquo;This is about shooting home that this is a serious situation and can get anybody. The fact we&rsquo;re actually debating this I think says to me that the campaign we&rsquo;ve approved is working,&rdquo; he said. The age of the woman in the ad has sparked controversy, with most younger Australians still ineligible to receive their vaccine. But with 11 of the 52 people in hospital across NSW under 35, Labor frontbencher Tanya Plibersek warned the Delta variant was &ldquo;hitting younger people as well&rdquo;. Labor had long demanded a national Covid-19 advertising campaign, which Ms Plibersek said was delayed as a result of the government&rsquo;s sluggish vaccine rollout. &ldquo;Perhaps the reason it&rsquo;s taken so long is if you encourage people to go and get vaccinated, you&rsquo;ve got to have enough of the vaccine available. We simply haven&rsquo;t; we&rsquo;ve been absolutely behind the eight ball in getting another vaccine for Australians,&rdquo; she told Sunrise. Labor frontbencher Chris Bowen, whose western Sydney electorate was in the grip of the outbreak, said the issue was &ldquo;not vaccine hesitancy so much, it&rsquo;s vaccine scarcity&rdquo;. He accepted there was a role for &ldquo;pointing out the consequences of not getting vaccinated&rdquo; to those that were hesitant about the jab, but said the new campaign lacked the &ldquo;creative spark&rdquo; of the Grim Reaper ads. &ldquo;That was a very tough message, a very stark message, but in a very creative way. I think the government really needs to rethink this advertising campaign from scratch; it&rsquo;s too late, and it&rsquo;s pretty low impact,&rdquo; he told ABC radio. He also dismissed the &ldquo;Arm Yourself&rdquo; campaign as &ldquo;very low energy&rdquo;. &ldquo;I don&rsquo;t think that&rsquo;s going to have any impact,&rdquo; he said.","image":[{"@type":"ImageObject","url":"https://images.perthnow.com.au/publication/C-3376985/6c07502f73bdccd45d879356219c325574873a6d-16x9-x0y444w1151h647.jpg","width":1151,"height":647},{"@type":"ImageObject","url":"https://images.perthnow.com.au/publication/C-3376985/6c07502f73bdccd45d879356219c325574873a6d-4x3-x0y336w1151h863.jpg","width":1151,"height":863}],"thumbnailUrl":"https://images.perthnow.com.au/publication/C-3376985/6c07502f73bdccd45d879356219c325574873a6d-16x9-x0y444w1151h647.jpg","url":"https://www.perthnow.com.au/news/government-defends-graphic-covid-19-ad-after-backlash-c-3376985","author":{"@type":"Organization","name":"NCA NewsWire"},"name":"Government defends graphic Covid-19 ad after backlash"}</script><span itemprop="author name">Jenny Smith</span></span></body></html>''')
     assert metadata.author == 'Jenny Smith'
+    assert metadata.pagetype == 'newsarticle'
 
     metadata = Document()
     metadata = extract_meta_json(html.fromstring('''<html><body><script type="application/ld+json" class="yoast-schema-graph">{"@context":"https://schema.org","@graph":[{"@type":"WebPage","@id":"https://www.bvoltaire.fr/jean-sevillia-letat-francais-et-letat-algerien-doivent-reconnaitre-les-crimes-commis-des-deux-cotes/#webpage","url":"https://www.bvoltaire.fr/jean-sevillia-letat-francais-et-letat-algerien-doivent-reconnaitre-les-crimes-commis-des-deux-cotes/","name":"Jean S\u00e9villia : \"L'\u00c9tat fran\u00e7ais et l'\u00c9tat alg\u00e9rien doivent reconna\u00eetre les crimes commis des deux c\u00f4t\u00e9s\" - Boulevard Voltaire","datePublished":"2018-09-13T12:21:13+00:00","dateModified":"2018-09-14T12:33:14+00:00","inLanguage":"fr-FR"},{"@type":"Article","@id":"https://www.bvoltaire.fr/jean-sevillia-letat-francais-et-letat-algerien-doivent-reconnaitre-les-crimes-commis-des-deux-cotes/#article","isPartOf":{"@id":"https://www.bvoltaire.fr/jean-sevillia-letat-francais-et-letat-algerien-doivent-reconnaitre-les-crimes-commis-des-deux-cotes/#webpage"},"author":{"@id":"https://www.bvoltaire.fr/#/schema/person/96c0ed8f089950c46afc2044cb23e8da"},"headline":"Jean S\u00e9villia : &#8220;L&#8217;\u00c9tat fran\u00e7ais et l&#8217;\u00c9tat alg\u00e9rien doivent reconna\u00eetre les crimes commis des deux c\u00f4t\u00e9s&#8221;","datePublished":"2018-09-13T12:21:13+00:00","dateModified":"2018-09-14T12:33:14+00:00","mainEntityOfPage":{"@id":"https://www.bvoltaire.fr/jean-sevillia-letat-francais-et-letat-algerien-doivent-reconnaitre-les-crimes-commis-des-deux-cotes/#webpage"},"publisher":{"@id":"https://www.bvoltaire.fr/#organization"},"image":{"@id":"https://www.bvoltaire.fr/jean-sevillia-letat-francais-et-letat-algerien-doivent-reconnaitre-les-crimes-commis-des-deux-cotes/#primaryimage"},"keywords":"Guerre d'Alg\u00e9rie","articleSection":"Audio,Editoriaux,Entretiens,Histoire","inLanguage":"fr-FR"},{"@type":"Person","@id":"https://www.bvoltaire.fr/#/schema/person/96c0ed8f089950c46afc2044cb23e8da","name":"Jean S\u00e9villia","image":{"@type":"ImageObject","@id":"https://www.bvoltaire.fr/#personlogo","inLanguage":"fr-FR","url":"https://secure.gravatar.com/avatar/1dd0ad5cb1fc3695880af1725477b22e?s=96&d=mm&r=g","caption":"Jean S\u00e9villia"},"description":"R\u00e9dacteur en chef adjoint au Figaro Magazine, membre du comit\u00e9 scientifique du Figaro Histoire, et auteur de biographies et d\u2019essais historiques.","sameAs":["https://www.bvoltaire.fr/"]}]}</script></body></html>'''), metadata)
     assert metadata.author == "Jean Sévillia"
+    assert metadata.pagetype == 'webpage'
 
     ### Test for potential errors
     metadata = Document()
@@ -52,6 +55,7 @@ def test_json_extraction():
 </script>
 </body></html>'''), metadata)
     assert metadata is not None and metadata.title == 'Apple Spring Forward Event Live Blog'
+    assert metadata is not None and metadata.pagetype == 'liveblogposting'
 
     ### Test for potential errors
     metadata = Document()
@@ -92,6 +96,7 @@ def test_json_extraction():
 </body></html>'''), metadata)
 
     assert metadata is not None and metadata.title == 'Apple Spring Forward Event Live Blog'
+    assert metadata is not None and metadata.pagetype == 'liveblogposting'
 
     ### Test for potential errors - Missing content on live blog
     metadata = Document()
@@ -116,6 +121,7 @@ def test_json_extraction():
     </body></html>'''), metadata)
 
     assert metadata is not None and metadata.title == 'Apple Spring Forward Event Live Blog'
+    assert metadata is not None and metadata.pagetype == 'liveblogposting'
 
     metadata = Document()
     metadata = extract_meta_json(html.fromstring('''
@@ -150,6 +156,7 @@ def test_json_extraction():
 </script>
 </body></html>'''), metadata)
     assert metadata is not None and metadata.author == 'Douglas Noel Adams'
+    assert metadata is not None and metadata.pagetype == 'socialmediaposting'
 
     metadata = Document()
     metadata = extract_meta_json(html.fromstring('''
@@ -178,6 +185,7 @@ def test_json_extraction():
 </script>
 </body></html>'''), metadata)
     assert metadata is not None and len(metadata.categories) == 0
+    assert metadata is not None and metadata.pagetype == 'article'
 
     metadata = Document()
     metadata = extract_meta_json(html.fromstring('''
@@ -287,7 +295,7 @@ def test_json_extraction():
     </script>
 </script>
 </body></html>'''), metadata)
-    assert metadata is not None and metadata.title == "Mickelson comments hurt new league: Norman" and metadata.sitename == "7NEWS" and metadata.author == "Digital Staff" and "Golf" in metadata.categories
+    assert metadata is not None and metadata.title == "Mickelson comments hurt new league: Norman" and metadata.sitename == "7NEWS" and metadata.author == "Digital Staff" and "Golf" in metadata.categories and metadata.pagetype == 'newsarticle'
 
     metadata = Document()
     metadata = extract_meta_json(html.fromstring('''
@@ -328,7 +336,7 @@ def test_json_extraction():
     </script>
 </script>
 </body></html>'''), metadata)
-    assert metadata is not None and metadata.title == "Australians stuck in Shanghai's COVID lockdown beg consular officials to help them flee" and metadata.author == "Bill Birtles" and metadata.sitename == "ABC News"
+    assert metadata is not None and metadata.title == "Australians stuck in Shanghai's COVID lockdown beg consular officials to help them flee" and metadata.author == "Bill Birtles" and metadata.sitename == "ABC News" and metadata.pagetype == 'newsarticle'
 
     metadata = Document()
     metadata = extract_meta_json(html.fromstring('''
@@ -433,7 +441,7 @@ def test_json_extraction():
     </script>
 </script>
 </body></html>'''), metadata)
-    assert metadata is not None and metadata.title == "New York City Enters Higher Coronavirus Risk Level as Case Numbers Rise" and metadata.author == "Sharon Otterman; Emma G Fitzsimmons" and metadata.sitename == "The New York Times"
+    assert metadata is not None and metadata.title == "New York City Enters Higher Coronavirus Risk Level as Case Numbers Rise" and metadata.author == "Sharon Otterman; Emma G Fitzsimmons" and metadata.sitename == "The New York Times" and metadata.pagetype == 'newsarticle'
 
     metadata = Document()
     metadata = extract_meta_json(html.fromstring('''
@@ -523,7 +531,7 @@ def test_json_extraction():
     </script>
 </script>
 </body></html>'''), metadata)
-    assert metadata is not None and metadata.title == "12 words and phrases you need to survive in Hamburg" and metadata.author == "Alexander Johnstone" and metadata.sitename == "The Local"
+    assert metadata is not None and metadata.title == "12 words and phrases you need to survive in Hamburg" and metadata.author == "Alexander Johnstone" and metadata.sitename == "The Local" and metadata.pagetype == 'newsarticle'
 
     metadata = Document()
     metadata = extract_meta_json(html.fromstring('''
@@ -573,7 +581,7 @@ def test_json_extraction():
         }
 </script>
 </body></html>'''), metadata)
-    assert metadata is not None and metadata.author is None and metadata.sitename == "Andreessen Horowitz"
+    assert metadata is not None and metadata.author is None and metadata.sitename == "Andreessen Horowitz" and metadata.pagetype == 'website'
 
     metadata = Document()
     metadata = extract_meta_json(html.fromstring('''
@@ -589,7 +597,7 @@ def test_json_extraction():
 </script>
 </body></html>'''), metadata)
 
-    assert metadata is not None and metadata.author is None and metadata.sitename is None
+    assert metadata is not None and metadata.author is None and metadata.sitename is None and metadata.pagetype is None
 
     metadata = Document()
     metadata = extract_meta_json(html.fromstring('''
@@ -618,7 +626,7 @@ def test_json_extraction():
     </script>
     </body></html>'''), metadata)
 
-    assert metadata is not None and metadata.author is None and metadata.sitename is None
+    assert metadata is not None and metadata.author is None and metadata.sitename is None and metadata.pagetype == 'liveblogposting'
 
     metadata = Document()
     metadata = extract_meta_json(html.fromstring('''
@@ -646,7 +654,7 @@ def test_json_extraction():
 }
 </script>
 </body></html>'''), metadata)
-    assert metadata is not None and metadata.title == 'Apple Spring Forward Event Live Blog'
+    assert metadata is not None and metadata.title == 'Apple Spring Forward Event Live Blog' and metadata.pagetype == 'liveblogposting'
 
     metadata = Document()
     metadata = extract_meta_json(html.fromstring('''
@@ -697,7 +705,7 @@ def test_json_extraction():
 </script>
 </body></html>'''), metadata)
 
-    assert metadata is not None and metadata.title == "EastEnders' June Brown leaves soap 'for good'" and metadata.sitename == "BBC News"
+    assert metadata is not None and metadata.title == "EastEnders' June Brown leaves soap 'for good'" and metadata.sitename == "BBC News" and metadata.pagetype == 'reportagenewsarticle'
 
     metadata = Document()
     metadata.sitename = "https://bbcnews.com"
@@ -721,7 +729,7 @@ def test_json_extraction():
     </script>
     </body></html>'''), metadata)
 
-    assert metadata is not None and metadata.sitename == "BBC News"
+    assert metadata is not None and metadata.sitename == "BBC News" and metadata.pagetype == 'reportagenewsarticle'
 
     metadata = Document()
     metadata = extract_meta_json(html.fromstring('''
@@ -753,7 +761,7 @@ def test_json_extraction():
     </script>
     </body></html>'''), metadata)
 
-    assert metadata is not None and metadata.author == "John Doe" and metadata.title == "How to Tie a Reef Knot"
+    assert metadata is not None and metadata.author == "John Doe" and metadata.title == "How to Tie a Reef Knot" and metadata.pagetype == 'article'
 
     metadata = Document()
     metadata = extract_meta_json(html.fromstring('''
@@ -772,7 +780,7 @@ def test_json_extraction():
         </script>
     </script>
     </body></html>'''), metadata)
-    assert metadata is not None and metadata.author == "Bill Birtles; John Smith"
+    assert metadata is not None and metadata.author == "Bill Birtles; John Smith" and metadata.pagetype == 'newsarticle'
 
     metadata = Document()
     metadata = extract_meta_json(html.fromstring('''
@@ -790,7 +798,7 @@ def test_json_extraction():
         </script>
     </body></html>'''), metadata)
 
-    assert metadata is not None and metadata.title is None and metadata.sitename is None
+    assert metadata is not None and metadata.title is None and metadata.sitename is None and metadata.pagetype is None
 
     metadata = Document()
     metadata = extract_meta_json(html.fromstring('''
@@ -846,7 +854,7 @@ def test_json_extraction():
         </script>
     </body></html>'''), metadata)
 
-    assert metadata is not None and metadata.title == "Find perfection in these places where land meets water." and metadata.sitename == "National Geographic" and metadata.author == "Kimberley Lovato"
+    assert metadata is not None and metadata.title == "Find perfection in these places where land meets water." and metadata.sitename == "National Geographic" and metadata.author == "Kimberley Lovato" and metadata.pagetype == 'article'
 
     # tests that "@type": [] in the JSON doesn't cause an exeption
 

--- a/tests/json_metadata_tests.py
+++ b/tests/json_metadata_tests.py
@@ -891,5 +891,20 @@ def test_json_extraction():
 
     assert metadata is not None
 
+    # tests if the JSON-LD with html entities is parsed correctly
+    metadata = Document()
+    metadata = extract_meta_json(html.fromstring(
+    """
+    <html>
+    <body>
+        <script type="application/ld+json">
+        &#13;{&#13;"@context":"http://schema.org",&#13;"@type":"WebSite",&#13;"url":"https://example.com/",&#13;"potentialAction":{&#13;"@type":"SearchAction",&#13;"target":"https://example.com/?s={search_term_string}",&#13;"query-input":"required name=search_term_string"&#13;}&#13;}&#13;
+        </script>
+    </body>
+    </html>
+    """), metadata)
+
+    assert metadata.pagetype == 'website'
+
 if __name__ == '__main__':
     test_json_extraction()

--- a/tests/metadata_tests.py
+++ b/tests/metadata_tests.py
@@ -198,7 +198,8 @@ def test_sitename():
 
 def test_meta():
     '''Test extraction out of meta-elements'''
-    metadata = extract_metadata('<html><head><meta property="og:title" content="Open Graph Title"/><meta property="og:author" content="Jenny Smith"/><meta property="og:description" content="This is an Open Graph description"/><meta property="og:site_name" content="My first site"/><meta property="og:url" content="https://example.org/test"/></head><body><a rel="license" href="https://creativecommons.org/">Creative Commons</a></body></html>')
+    metadata = extract_metadata('<html><head><meta property="og:title" content="Open Graph Title"/><meta property="og:author" content="Jenny Smith"/><meta property="og:description" content="This is an Open Graph description"/><meta property="og:site_name" content="My first site"/><meta property="og:url" content="https://example.org/test"/><meta property="og:type" content="Open Graph Type"/></head><body><a rel="license" href="https://creativecommons.org/">Creative Commons</a></body></html>')
+    assert metadata.pagetype == 'Open Graph Type'
     assert metadata.title == 'Open Graph Title'
     assert metadata.author == 'Jenny Smith'
     assert metadata.description == 'This is an Open Graph description'

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -147,14 +147,15 @@ def test_input():
 
 def test_txttocsv():
     mymeta = Document()
-    assert utils.txttocsv('', '', mymeta) == 'None\tNone\tNone\tNone\tNone\tNone\t\t\tNone\n'
+    assert utils.txttocsv('', '', mymeta) == 'None\tNone\tNone\tNone\tNone\tNone\t\t\tNone\tNone\n'
     mymeta.title = 'Test title'
     mymeta.url = 'https://example.org'
     mymeta.hostname = 'example.org'
     mymeta.id = '1'
     mymeta.license = 'CC BY-SA'
     mymeta.image = 'https://example.org/image.jpg'
-    assert utils.txttocsv('Test text', 'Test comment', mymeta) == '1\thttps://example.org\tNone\texample.org\tTest title\thttps://example.org/image.jpg\tNone\tTest text\tTest comment\tCC BY-SA\n'
+    mymeta.pagetype = 'article'
+    assert utils.txttocsv('Test text', 'Test comment', mymeta) == '1\thttps://example.org\tNone\texample.org\tTest title\thttps://example.org/image.jpg\tNone\tTest text\tTest comment\tCC BY-SA\tarticle\n'
     mystring = '<html><body><p>ÄÄÄÄÄÄÄÄÄÄÄÄÄÄ</p></body></html>'
     assert extract(mystring, output_format='csv', config=ZERO_CONFIG) is not None
     assert extract(mystring, output_format='csv', include_comments=False, config=ZERO_CONFIG).endswith('\tNone\n')
@@ -164,7 +165,7 @@ def test_txttocsv():
     assert extract(mystring, output_format='json', include_comments=False, config=ZERO_CONFIG).endswith('}')
     # bare extraction for python
     result = bare_extraction(mystring, config=ZERO_CONFIG, as_dict=True)
-    assert isinstance(result, dict) and len(result) == 19
+    assert isinstance(result, dict) and len(result) == 20
 
 
 def test_exotic_tags(xmloutput=False):

--- a/trafilatura/json_metadata.py
+++ b/trafilatura/json_metadata.py
@@ -9,7 +9,7 @@ from .utils import normalize_authors, trim
 
 
 JSON_ARTICLE_SCHEMA = {"article", "backgroundnewsarticle", "blogposting", "medicalscholarlyarticle", "newsarticle", "opinionnewsarticle", "reportagenewsarticle", "scholarlyarticle", "socialmediaposting", "liveblogposting"}
-JSON_OGTYPE_SCHEMA = {'aboutpage', 'checkoutpage', 'collectionpage', 'contactpage', 'faqpage', 'itempage', 'medicalwebpage', 'profilepage', 'qapage', 'realestatelisting', 'searchresultspage', 'webpage', 'website', 'article', 'advertisercontentarticle', 'newsarticle', 'analysisnewsarticle', 'askpublicnewsarticle', 'backgroundnewsarticle', 'opinionnewsarticle', 'reportagenewsarticle', 'reviewnewsarticle', 'report', 'satiricalarticle', 'scholarlyarticle', 'medicalscholarlyarticle', 'socialmediaposting', 'blogposting', 'liveblogposting', 'discussionforumposting', 'techarticle', 'blog'}
+JSON_OGTYPE_SCHEMA = {"aboutpage", "checkoutpage", "collectionpage", "contactpage", "faqpage", "itempage", "medicalwebpage", "profilepage", "qapage", "realestatelisting", "searchresultspage", "webpage", "website", "article", "advertisercontentarticle", "newsarticle", "analysisnewsarticle", "askpublicnewsarticle", "backgroundnewsarticle", "opinionnewsarticle", "reportagenewsarticle", "reviewnewsarticle", "report", "satiricalarticle", "scholarlyarticle", "medicalscholarlyarticle", "socialmediaposting", "blogposting", "liveblogposting", "discussionforumposting", "techarticle", "blog", "jobposting"}
 JSON_PUBLISHER_SCHEMA = {"newsmediaorganization", "organization", "webpage", "website"}
 JSON_AUTHOR_1 = re.compile(r'"author":[^}[]+?"name?\\?": ?\\?"([^"\\]+)|"author"[^}[]+?"names?".+?"([^"]+)', re.DOTALL)
 JSON_AUTHOR_2 = re.compile(r'"[Pp]erson"[^}]+?"names?".+?"([^"]+)', re.DOTALL)

--- a/trafilatura/json_metadata.py
+++ b/trafilatura/json_metadata.py
@@ -9,11 +9,13 @@ from .utils import normalize_authors, trim
 
 
 JSON_ARTICLE_SCHEMA = {"article", "backgroundnewsarticle", "blogposting", "medicalscholarlyarticle", "newsarticle", "opinionnewsarticle", "reportagenewsarticle", "scholarlyarticle", "socialmediaposting", "liveblogposting"}
+JSON_OGTYPE_SCHEMA = {'aboutpage', 'checkoutpage', 'collectionpage', 'contactpage', 'faqpage', 'itempage', 'medicalwebpage', 'profilepage', 'qapage', 'realestatelisting', 'searchresultspage', 'webpage', 'website', 'article', 'advertisercontentarticle', 'newsarticle', 'analysisnewsarticle', 'askpublicnewsarticle', 'backgroundnewsarticle', 'opinionnewsarticle', 'reportagenewsarticle', 'reviewnewsarticle', 'report', 'satiricalarticle', 'scholarlyarticle', 'medicalscholarlyarticle', 'socialmediaposting', 'blogposting', 'liveblogposting', 'discussionforumposting', 'techarticle', 'blog'}
 JSON_PUBLISHER_SCHEMA = {"newsmediaorganization", "organization", "webpage", "website"}
 JSON_AUTHOR_1 = re.compile(r'"author":[^}[]+?"name?\\?": ?\\?"([^"\\]+)|"author"[^}[]+?"names?".+?"([^"]+)', re.DOTALL)
 JSON_AUTHOR_2 = re.compile(r'"[Pp]erson"[^}]+?"names?".+?"([^"]+)', re.DOTALL)
 JSON_AUTHOR_REMOVE = re.compile(r',?(?:"\w+":?[:|,\[])?{?"@type":"(?:[Ii]mageObject|[Oo]rganization|[Ww]eb[Pp]age)",[^}[]+}[\]|}]?')
 JSON_PUBLISHER = re.compile(r'"publisher":[^}]+?"name?\\?": ?\\?"([^"\\]+)', re.DOTALL)
+JSON_TYPE = re.compile(r'"@type"\s*:\s*"([^"]*)"', re.DOTALL)
 JSON_CATEGORY = re.compile(r'"articleSection": ?"([^"\\]+)', re.DOTALL)
 JSON_NAME = re.compile(r'"@type":"[Aa]rticle", ?"name": ?"([^"\\]+)', re.DOTALL)
 JSON_HEADLINE = re.compile(r'"headline": ?"([^"\\]+)', re.DOTALL)
@@ -47,6 +49,9 @@ def extract_json(schema, metadata):
                 content_type = content["@type"][0].lower()
             else:
                 content_type = content["@type"].lower()
+
+            if content_type in JSON_OGTYPE_SCHEMA and metadata.pagetype is None:
+                metadata.pagetype = normalize_json(content_type)
 
             if content_type in JSON_PUBLISHER_SCHEMA:
                 for candidate in ("name", "alternateName"):
@@ -128,6 +133,12 @@ def extract_json_parse_error(elem, metadata):
             author = extract_json_author(element_text_author, JSON_AUTHOR_2)
         if author is not None:
             metadata.author = author
+    # try to extract page type as an alternative to og:type
+    if "@type" in elem:
+        mymatch = JSON_TYPE.search(elem)
+        candidate = normalize_json(mymatch[1].lower())
+        if mymatch and candidate in JSON_OGTYPE_SCHEMA:
+            metadata.pagetype = candidate
     # try to extract publisher
     if '"publisher"' in elem:
         mymatch = JSON_PUBLISHER.search(elem)

--- a/trafilatura/json_metadata.py
+++ b/trafilatura/json_metadata.py
@@ -1,12 +1,12 @@
 """
 Functions needed to scrape metadata from JSON-LD format.
+For reference, here is the list of all JSON-LD types: https://schema.org/docs/full.html
 """
 
 import json
 import re
 
 from .utils import normalize_authors, trim
-
 
 JSON_ARTICLE_SCHEMA = {"article", "backgroundnewsarticle", "blogposting", "medicalscholarlyarticle", "newsarticle", "opinionnewsarticle", "reportagenewsarticle", "scholarlyarticle", "socialmediaposting", "liveblogposting"}
 JSON_OGTYPE_SCHEMA = {"aboutpage", "checkoutpage", "collectionpage", "contactpage", "faqpage", "itempage", "medicalwebpage", "profilepage", "qapage", "realestatelisting", "searchresultspage", "webpage", "website", "article", "advertisercontentarticle", "newsarticle", "analysisnewsarticle", "askpublicnewsarticle", "backgroundnewsarticle", "opinionnewsarticle", "reportagenewsarticle", "reviewnewsarticle", "report", "satiricalarticle", "scholarlyarticle", "medicalscholarlyarticle", "socialmediaposting", "blogposting", "liveblogposting", "discussionforumposting", "techarticle", "blog", "jobposting"}
@@ -50,6 +50,7 @@ def extract_json(schema, metadata):
             else:
                 content_type = content["@type"].lower()
 
+            # The "pagetype" should only be returned if the page is some kind of an article, category, website...
             if content_type in JSON_OGTYPE_SCHEMA and metadata.pagetype is None:
                 metadata.pagetype = normalize_json(content_type)
 

--- a/trafilatura/metadata.py
+++ b/trafilatura/metadata.py
@@ -27,7 +27,7 @@ class Document:
     'title', 'author', 'url', 'hostname', 'description', 'sitename',
     'date', 'categories', 'tags', 'fingerprint', 'id', 'license',
     'body', 'comments', 'commentsbody', 'raw_text', 'text',
-    'language', 'image',  # 'locale'?
+    'language', 'image', 'pagetype'  # 'locale'?
     ]
     # consider dataclasses for Python 3.7+
     def __init__(self):
@@ -128,7 +128,7 @@ def extract_meta_json(tree, metadata):
 
 def extract_opengraph(tree):
     '''Search meta tags following the OpenGraph guidelines (https://ogp.me/)'''
-    title, author, url, description, site_name, image = (None,) * 6
+    title, author, url, description, site_name, image, pagetype = (None,) * 7
     # detect OpenGraph schema
     for elem in tree.xpath('.//head/meta[starts-with(@property, "og:")]'):
         # safeguard
@@ -160,22 +160,22 @@ def extract_opengraph(tree):
         elif elem.get('property') == 'og:image:secure_url':
             image = elem.get('content')
         # og:type
-        # elif elem.get('property') == 'og:type':
-        #    pagetype = elem.get('content')
+        elif elem.get('property') == 'og:type':
+           pagetype = elem.get('content')
         # og:locale
         # elif elem.get('property') == 'og:locale':
         #    pagelocale = elem.get('content')
-    return title, author, url, description, site_name, image
+    return title, author, url, description, site_name, image, pagetype
 
 
 def examine_meta(tree):
     '''Search meta tags for relevant information'''
     metadata = Document()  # alt: Metadata()
     # bootstrap from potential OpenGraph tags
-    title, author, url, description, site_name, image = extract_opengraph(tree)
+    title, author, url, description, site_name, image, pagetype = extract_opengraph(tree)
     # test if all return values have been assigned
-    if all((title, author, url, description, site_name, image)):  # if they are all defined
-        metadata.title, metadata.author, metadata.url, metadata.description, metadata.sitename, metadata.image = title, author, url, description, site_name, image
+    if all((title, author, url, description, site_name, image, pagetype)):  # if they are all defined
+        metadata.title, metadata.author, metadata.url, metadata.description, metadata.sitename, metadata.image, metadata.pagetype = title, author, url, description, site_name, image, pagetype
         return metadata
     tags, backup_sitename = [], None
     # skim through meta tags
@@ -246,7 +246,7 @@ def examine_meta(tree):
     if site_name is None and backup_sitename is not None:
         site_name = backup_sitename
     # copy
-    metadata.title, metadata.author, metadata.url, metadata.description, metadata.sitename, metadata.tags, metadata.image = title, author, url, description, site_name, tags, image
+    metadata.title, metadata.author, metadata.url, metadata.description, metadata.sitename, metadata.tags, metadata.image, metadata.pagetype = title, author, url, description, site_name, tags, image, pagetype
     return metadata
 
 

--- a/trafilatura/metadata.py
+++ b/trafilatura/metadata.py
@@ -5,6 +5,7 @@ Module bundling all functions needed to scrape metadata from webpages.
 import json
 import logging
 import re
+import html
 
 from copy import deepcopy
 
@@ -117,7 +118,7 @@ def extract_meta_json(tree, metadata):
     for elem in tree.xpath('.//script[@type="application/ld+json" or @type="application/settings+json"]'):
         if not elem.text:
             continue
-        element_text = JSON_MINIFY.sub(r'\1', elem.text)
+        element_text = html.unescape(JSON_MINIFY.sub(r'\1', elem.text))
         try:
             schema = json.loads(element_text)
             metadata = extract_json(schema, metadata)

--- a/trafilatura/utils.py
+++ b/trafilatura/utils.py
@@ -237,7 +237,7 @@ def txttocsv(text, comments, docmeta):
     if comments is not None:
         comments = trim(' '.join(comments.splitlines()))
     tsv_output = \
-        f'{docmeta.url}\t{docmeta.fingerprint}\t{docmeta.hostname}\t{docmeta.title}\t{docmeta.image}\t{docmeta.date}\t{text}\t{comments}\t{docmeta.license}\n'
+        f'{docmeta.url}\t{docmeta.fingerprint}\t{docmeta.hostname}\t{docmeta.title}\t{docmeta.image}\t{docmeta.date}\t{text}\t{comments}\t{docmeta.license}\t{docmeta.pagetype}\n'
     # add id up front if provided
     if docmeta.id is not None:
         tsv_output = docmeta.id + '\t' + tsv_output


### PR DESCRIPTION
This implements https://github.com/adbar/trafilatura/issues/307

- Extract from og:type
- If no og:type tag, try to extract from ld+json
- On some sites the variable `element_text` was coming with bad html formatting causing error and having to use `extract_json_parse_error`. This patch fix the problem with `html.unescape()`
- Tests were done but I'm not sure if I should put validation in all extract_meta_json tests

OBS: I realized that json_metadata already had some `@type` implementations but I preferred not to change it to prevent break anything and implemented it with new conditions and lists (not sure if this is the ideal approach)

OBS2: I think txttocsv function and test_txttocsv should be refactored. Every minor change in metadata breaks the test.

OBS3: extract_meta_json function could be simplified and refactored

OBS4: Only returns pagetype from ld+json if the page is some kind of an article/category/home/site/bloc etc... got types from https://schema.org/docs/full.html