### PR TITLE
Fix handling of text content of <div> with empty <p> child

### DIFF
--- a/tests/xml_tei_tests.py
+++ b/tests/xml_tei_tests.py
@@ -425,6 +425,21 @@ def test_ab_with_p_parent_resolved():
     ]
 
 
+def test_handling_of_text_content_in_div():
+    xml_doc = fromstring("<TEI><text><body><div>text<head/></div></body></text></TEI>")
+    cleaned = check_tei(xml_doc, "fake_url")
+    assert cleaned.find(".//p").text == "text"
+    xml_doc = fromstring("<TEI><text><body><div>text1<p>text2</p></div></body></text></TEI>")
+    cleaned = check_tei(xml_doc, "fake_url")
+    assert cleaned.find(".//p").text == "text1 text2"
+    xml_doc = fromstring("<TEI><text><body><div>text<p/></div></body></text></TEI>")
+    cleaned = check_tei(xml_doc, "fake_url")
+    assert cleaned.find(".//p").text == "text"
+    xml_doc = fromstring("<TEI><text><body><div><p/></div>tail</body></text></TEI>")
+    cleaned = check_tei(xml_doc, "fake_url")
+    assert cleaned.find(".//p").text == "tail"
+
+
 if __name__ == "__main__":
     test_publisher_added_before_availability_in_publicationStmt()
     test_unwanted_siblings_of_div_removed()

--- a/trafilatura/xml.py
+++ b/trafilatura/xml.py
@@ -428,7 +428,7 @@ def write_fullheader(teidoc, docmeta):
 def _handle_text_content_of_div_nodes(element):
     if element.text is not None and element.text.strip():
         if element.getchildren() and element[0].tag == 'p':
-            p_text = element[0].text if element[0].text is not None else ""
+            p_text = element[0].text or ""
             element[0].text = ' '.join([element.text, p_text]).strip()
         else:
             new_child = Element("p")
@@ -437,7 +437,7 @@ def _handle_text_content_of_div_nodes(element):
         element.text = None
     if element.tail is not None and element.tail.strip():
         if element.getchildren() and element[-1].tag == 'p':
-            p_text = element[-1].text if element[-1].text is not None else ""
+            p_text = element[-1].text or ""
             element[-1].text = ' '.join([p_text, element.tail]).strip()
         else:
             new_child = Element("p")

--- a/trafilatura/xml.py
+++ b/trafilatura/xml.py
@@ -428,7 +428,8 @@ def write_fullheader(teidoc, docmeta):
 def _handle_text_content_of_div_nodes(element):
     if element.text is not None and element.text.strip():
         if element.getchildren() and element[0].tag == 'p':
-            element[0].text = ' '.join([element.text, element[0].text])
+            p_text = element[0].text if element[0].text is not None else ""
+            element[0].text = ' '.join([element.text, p_text]).strip()
         else:
             new_child = Element("p")
             new_child.text = element.text
@@ -436,7 +437,8 @@ def _handle_text_content_of_div_nodes(element):
         element.text = None
     if element.tail is not None and element.tail.strip():
         if element.getchildren() and element[-1].tag == 'p':
-            element[-1].text = ' '.join([element[-1].text, element.tail])
+            p_text = element[-1].text if element[-1].text is not None else ""
+            element[-1].text = ' '.join([p_text, element.tail]).strip()
         else:
             new_child = Element("p")
             new_child.text = element.tail


### PR DESCRIPTION
In the `check_tei` function, I fixed the bug that occurred during the cleaning of `<div/>` elements with text or tail content if there was an empty `<p/>` child present.