### PR TITLE
fix: html with no metadata image

### DIFF
--- a/tests/metadata_tests.py
+++ b/tests/metadata_tests.py
@@ -280,6 +280,9 @@ def test_images():
     assert metadata.image == 'https://example.org/example-opengraph.jpg'
     metadata = extract_metadata('<html><head><meta property="twitter:image" content="https://example.org/example-twitter.jpg"></html>')
     assert metadata.image == 'https://example.org/example-twitter.jpg'
+    '''Without Image'''
+    metadata = extract_metadata('<html><head><meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" /></html>')
+    assert metadata.image == None
 
 def test_Document_as_dict():
     """Tests that the dict serialization works and preserves data."""

--- a/trafilatura/metadata.py
+++ b/trafilatura/metadata.py
@@ -463,7 +463,7 @@ def extract_image(tree):
     '''Search meta tags following the OpenGraph guidelines (https://ogp.me/)
        and search meta tags with Twitter Image'''
 
-    for elem in tree.xpath('.//head/meta[@property="og:image" or "og:image:url"][@content]'):
+    for elem in tree.xpath('.//head/meta[@property="og:image" or @property="og:image:url"][@content]'):
         return elem.get('content')
 
     for elem in tree.xpath('.//head/meta[@property="twitter:image" or @property="twitter:image:src"][@content]'):


### PR DESCRIPTION
I noticed that the current implementation of the xpath selector may return the wrong content in some cases. Specifically, when there is no og:image property present

To fix this, I updated the xpath selector.