### PR TITLE
feat: use proxy to extract data

### DIFF
--- a/tests/downloads_tests.py
+++ b/tests/downloads_tests.py
@@ -62,13 +62,13 @@ def test_fetch():
     # doesn't work?
     # assert _send_request('https://expired.badssl.com/', False, False, DEFAULT_CONFIG) is not None
     if pycurl is not None:
-        assert _send_pycurl_request('https://expired.badssl.com/', False, DEFAULT_CONFIG) is not None
+        assert _send_pycurl_request('https://expired.badssl.com/', False, False, DEFAULT_CONFIG) is not None
     # no SSL, no decoding
     url = 'https://httpbin.org/status/200'
     response = _send_request('https://httpbin.org/status/200', True, False, DEFAULT_CONFIG)
     assert response.data == b''
     if pycurl is not None:
-        response1 = _send_pycurl_request('https://httpbin.org/status/200', True, DEFAULT_CONFIG)
+        response1 = _send_pycurl_request('https://httpbin.org/status/200', True, False, DEFAULT_CONFIG)
         assert _handle_response(url, response1, False, DEFAULT_CONFIG) == _handle_response(url, response, False, DEFAULT_CONFIG)
         assert _handle_response(url, response1, True, DEFAULT_CONFIG) == _handle_response(url, response, True, DEFAULT_CONFIG)
     # response object

--- a/tests/downloads_tests.py
+++ b/tests/downloads_tests.py
@@ -45,7 +45,7 @@ UA_CONFIG = use_config(filename=os.path.join(RESOURCES_DIR, 'newsettings.cfg'))
 def test_fetch():
     '''Test URL fetching.'''
     # logic: empty request?
-    assert _send_request('', True, DEFAULT_CONFIG) is None
+    assert _send_request('', True, False, DEFAULT_CONFIG) is None
 
     # is_live general tests
     assert _urllib3_is_live_page('https://httpstat.us/301') is True
@@ -60,12 +60,12 @@ def test_fetch():
     assert fetch_url('https://httpstat.us/404') is None
     # test if the functions default to no_ssl
     # doesn't work?
-    # assert _send_request('https://expired.badssl.com/', False, DEFAULT_CONFIG) is not None
+    # assert _send_request('https://expired.badssl.com/', False, False, DEFAULT_CONFIG) is not None
     if pycurl is not None:
         assert _send_pycurl_request('https://expired.badssl.com/', False, DEFAULT_CONFIG) is not None
     # no SSL, no decoding
     url = 'https://httpbin.org/status/200'
-    response = _send_request('https://httpbin.org/status/200', True, DEFAULT_CONFIG)
+    response = _send_request('https://httpbin.org/status/200', True, False, DEFAULT_CONFIG)
     assert response.data == b''
     if pycurl is not None:
         response1 = _send_pycurl_request('https://httpbin.org/status/200', True, DEFAULT_CONFIG)
@@ -73,7 +73,7 @@ def test_fetch():
         assert _handle_response(url, response1, True, DEFAULT_CONFIG) == _handle_response(url, response, True, DEFAULT_CONFIG)
     # response object
     url = 'https://httpbin.org/encoding/utf8'
-    response = _send_request(url, False, DEFAULT_CONFIG)
+    response = _send_request(url, False, False, DEFAULT_CONFIG)
     myobject = _handle_response(url, response, False, DEFAULT_CONFIG)
     assert myobject.data.startswith(b'<h1>Unicode Demo</h1>')
     # too large response object
@@ -166,3 +166,4 @@ if __name__ == '__main__':
     test_config()
     test_decode()
     test_queue()
+    

--- a/trafilatura/downloads.py
+++ b/trafilatura/downloads.py
@@ -174,7 +174,7 @@ def fetch_url(url, decode=True, no_ssl=False, use_proxy=False, config=DEFAULT_CO
     if pycurl is None:
         response = _send_request(url, no_ssl, use_proxy, config)
     else:
-        response = _send_pycurl_request(url, no_ssl, config)
+        response = _send_pycurl_request(url, no_ssl, use_proxy, config)
     if response is not None and response != '':
         return _handle_response(url, response, decode, config)
         # return '' (useful do discard further processing?)
@@ -327,7 +327,7 @@ def _send_pycurl_request(url, no_ssl, use_proxy, config):
         # additional error codes: 80, 90, 96, 98
         if no_ssl is False and err.args[0] in (35, 54, 58, 59, 60, 64, 66, 77, 82, 83, 91):
             LOGGER.debug('retrying after SSL error: %s %s', url, err)
-            return _send_pycurl_request(url, True, config)
+            return _send_pycurl_request(url, True, use_proxy, config)
         # traceback.print_exc(file=sys.stderr)
         # sys.stderr.flush()
         return None


### PR DESCRIPTION
This PR implements https://github.com/adbar/trafilatura/issues/330 and solves the issue https://github.com/adbar/trafilatura/issues/210

I have updated the downloads_tests.py file to reflect these changes, although I have not included a proxy test at this time. It maybe possible to read a private proxy variable in .env/settings.cfg for tests.

I can confirm that the HTTP/HTTPS SSL proxies are working correctly.

In order to use Socks4/5 proxies with urllib3, it is necessary to install the urllib3[socks] package using the command `python -m pip install urllib3[socks]` as described here: https://urllib3.readthedocs.io/en/stable/advanced-usage.html#socks-proxies. I did not have access to a Socks proxy for testing, I was unable to include this feature in the current pull request.

Finally, the trafilatura.fetch_url() function now includes a new parameter use_proxy, which can be used to specify a proxy in the format https://proxy_user:proxy_pass@proxy_host:proxy_port.