### PR TITLE
improve code support

### DIFF
--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -1106,6 +1106,12 @@ print(p1.age) </code>'''
 from openai_function_call import openai_function</code>'''
     testresult = extract(pip, config=ZERO_CONFIG, output_format='xml')
     assert expected in testresult and 'quote' not in testresult
+    medium = '''<div><p>Code:</p>
+    <pre class="lw lx ly lz ma nq nr ns bo nt ba bj"><span id="fe48" class="nu mo ev nr b bf nv nw l nx ny" data-selectable-paragraph=""><span class="hljs-keyword">import</span> openai_function<br><br><span class="hljs-meta">@openai_function</span></span></pre>'''
+    expected = '''<code>import openai_function
+@openai_function</code>'''
+    testresult = extract(medium, config=ZERO_CONFIG, output_format='xml')
+    assert expected in testresult and 'quote' not in testresult
 
 
 if __name__ == '__main__':

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -1112,6 +1112,11 @@ from openai_function_call import openai_function</code>'''
     expected = '''<code>import openai_function<lb/><lb/>@openai_functiondef sum(a:int, b:int):<lb/>  """Sum description adds a + b"""</code>'''
     testresult = extract(medium_ssr, config=ZERO_CONFIG, output_format='xml')
     assert expected in testresult and 'quote' not in testresult
+    code_el = '''<div><p>Code:</p>
+    <pre><code><span>my code</span></code></pre>'''
+    expected = '''<code>my code</code>'''
+    testresult = extract(code_el, config=ZERO_CONFIG, output_format='xml')
+    assert expected in testresult and 'quote' not in testresult
 
 
 if __name__ == '__main__':

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -1106,11 +1106,17 @@ print(p1.age) </code>'''
 from openai_function_call import openai_function</code>'''
     testresult = extract(pip, config=ZERO_CONFIG, output_format='xml')
     assert expected in testresult and 'quote' not in testresult
-    medium = '''<div><p>Code:</p>
+    medium_js = '''<div><p>Code:</p>
     <pre class="lw lx ly lz ma nq nr ns bo nt ba bj"><span id="fe48" class="nu mo ev nr b bf nv nw l nx ny" data-selectable-paragraph=""><span class="hljs-keyword">import</span> openai_function<br><br><span class="hljs-meta">@openai_function</span></span></pre>'''
     expected = '''<code>import openai_function
 @openai_function</code>'''
-    testresult = extract(medium, config=ZERO_CONFIG, output_format='xml')
+    testresult = extract(medium_js, config=ZERO_CONFIG, output_format='xml')
+    assert expected in testresult and 'quote' not in testresult
+    medium_ssr = '''<div><p>Code:</p>
+    <pre class="lw lx ly lz ma nq nr ns bo nt ba bj"><span id="fe48" class="nu mo ev nr b bf nv nw l nx ny">import openai_function<br><br>@openai_function</span></pre>'''
+    expected = '''<code>import openai_function
+@openai_function</code>'''
+    testresult = extract(medium_ssr, config=ZERO_CONFIG, output_format='xml')
     assert expected in testresult and 'quote' not in testresult
 
 

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -1090,10 +1090,10 @@ for name and age:</p>
 </div>'''
     testresult = extract(w3schools, config=ZERO_CONFIG, output_format='xml')
     expected = '''<code>
-class Person:<lb/>  def __init__(self, name, age):<lb/>  
-  self.name = name<lb/>  self.age = age<lb/><lb/>p1 = Person("John", 
-  36)<lb/>
-  <lb/>print(p1.name)<lb/>print(p1.age) </code>'''
+class Person:<lb/> def __init__(self, name, age):<lb/>
+self.name = name<lb/> self.age = age<lb/><lb/>p1 = Person("John",
+36)<lb/>
+<lb/>print(p1.name)<lb/>print(p1.age) </code>'''
     assert expected in testresult and 'quote' not in testresult
     pip = '''<div><p>Code:</p>
     <pre lang="python3"><span class="kn">import</span> <span class="nn">openai</span>
@@ -1109,7 +1109,7 @@ from openai_function_call import openai_function</code>'''
     assert expected in testresult and 'quote' not in testresult
     medium_ssr = '''<div><p>Code:</p>
     <pre class="lw lx ly lz ma nq nr ns bo nt ba bj"><span id="fe48" class="nu mo ev nr b bf nv nw l nx ny">import openai_function<br><br>@openai_functiondef sum(a:int, b:int):<br/>  &quot;&quot;&quot;Sum description adds a + b&quot;&quot;&quot;</span></pre>'''
-    expected = '''<code>import openai_function<lb/><lb/>@openai_functiondef sum(a:int, b:int):<lb/>  """Sum description adds a + b"""</code>'''
+    expected = '<code>import openai_function<lb/><lb/>@openai_functiondef sum(a:int, b:int):<lb/> """Sum description adds a + b"""</code>'
     testresult = extract(medium_ssr, config=ZERO_CONFIG, output_format='xml')
     assert expected in testresult and 'quote' not in testresult
     code_el = '''<div><p>Code:</p>

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -1061,7 +1061,6 @@ def test_code_blocks():
 <span class="hljs-keyword">highlighted</span> more <span class="hljs-keyword">code</span>
 </code></pre>
 </div>'''
-    ''
     testresult = extract(highlightjs, config=ZERO_CONFIG, output_format='xml')
     assert '<code>code\nhighlighted more code\n</code>' in testresult and 'quote' not in testresult
     github = '''<div class="highlight highlight-source-shell notranslate position-relative overflow-auto" dir="auto"><pre>$ pip install PyGithub</pre><div class="zeroclipboard-container position-absolute right-0 top-0">
@@ -1099,6 +1098,13 @@ p1 = Person("John",
 36)
 print(p1.name)
 print(p1.age) </code>'''
+    assert expected in testresult and 'quote' not in testresult
+    pip = '''<div><p>Code:</p>
+    <pre lang="python3"><span class="kn">import</span> <span class="nn">openai</span>
+    <span class="kn">from</span> <span class="nn">openai_function_call</span> <span class="kn">import</span> <span class="n">openai_function</span></pre></div>'''
+    expected = '''<code>import openai
+from openai_function_call import openai_function</code>'''
+    testresult = extract(pip, config=ZERO_CONFIG, output_format='xml')
     assert expected in testresult and 'quote' not in testresult
 
 

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -1090,14 +1090,10 @@ for name and age:</p>
 </div>'''
     testresult = extract(w3schools, config=ZERO_CONFIG, output_format='xml')
     expected = '''<code>
-class Person:
-def __init__(self, name, age):
-self.name = name
-self.age = age
-p1 = Person("John",
-36)
-print(p1.name)
-print(p1.age) </code>'''
+class Person:<lb/> def __init__(self, name, age):<lb/>
+self.name = name<lb/> self.age = age<lb/><lb/>p1 = Person("John",
+36)<lb/>
+<lb/>print(p1.name)<lb/>print(p1.age) </code>'''
     assert expected in testresult and 'quote' not in testresult
     pip = '''<div><p>Code:</p>
     <pre lang="python3"><span class="kn">import</span> <span class="nn">openai</span>
@@ -1108,14 +1104,12 @@ from openai_function_call import openai_function</code>'''
     assert expected in testresult and 'quote' not in testresult
     medium_js = '''<div><p>Code:</p>
     <pre class="lw lx ly lz ma nq nr ns bo nt ba bj"><span id="fe48" class="nu mo ev nr b bf nv nw l nx ny" data-selectable-paragraph=""><span class="hljs-keyword">import</span> openai_function<br><br><span class="hljs-meta">@openai_function</span></span></pre>'''
-    expected = '''<code>import openai_function
-@openai_function</code>'''
+    expected = '''<code>import openai_function<lb/><lb/>@openai_function</code>'''
     testresult = extract(medium_js, config=ZERO_CONFIG, output_format='xml')
     assert expected in testresult and 'quote' not in testresult
     medium_ssr = '''<div><p>Code:</p>
-    <pre class="lw lx ly lz ma nq nr ns bo nt ba bj"><span id="fe48" class="nu mo ev nr b bf nv nw l nx ny">import openai_function<br><br>@openai_function</span></pre>'''
-    expected = '''<code>import openai_function
-@openai_function</code>'''
+    <pre class="lw lx ly lz ma nq nr ns bo nt ba bj"><span id="fe48" class="nu mo ev nr b bf nv nw l nx ny">import openai_function<br><br>@openai_functiondef sum(a:int, b:int):<br/>  &quot;&quot;&quot;Sum description adds a + b&quot;&quot;&quot;</span></pre>'''
+    expected = '''<code>import openai_function<lb/><lb/>@openai_functiondef sum(a:int, b:int):<lb/> """Sum description adds a + b"""</code>'''
     testresult = extract(medium_ssr, config=ZERO_CONFIG, output_format='xml')
     assert expected in testresult and 'quote' not in testresult
 

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -1090,10 +1090,10 @@ for name and age:</p>
 </div>'''
     testresult = extract(w3schools, config=ZERO_CONFIG, output_format='xml')
     expected = '''<code>
-class Person:<lb/> def __init__(self, name, age):<lb/>
-self.name = name<lb/> self.age = age<lb/><lb/>p1 = Person("John",
-36)<lb/>
-<lb/>print(p1.name)<lb/>print(p1.age) </code>'''
+class Person:<lb/>  def __init__(self, name, age):<lb/>  
+  self.name = name<lb/>  self.age = age<lb/><lb/>p1 = Person("John", 
+  36)<lb/>
+  <lb/>print(p1.name)<lb/>print(p1.age) </code>'''
     assert expected in testresult and 'quote' not in testresult
     pip = '''<div><p>Code:</p>
     <pre lang="python3"><span class="kn">import</span> <span class="nn">openai</span>
@@ -1109,7 +1109,7 @@ from openai_function_call import openai_function</code>'''
     assert expected in testresult and 'quote' not in testresult
     medium_ssr = '''<div><p>Code:</p>
     <pre class="lw lx ly lz ma nq nr ns bo nt ba bj"><span id="fe48" class="nu mo ev nr b bf nv nw l nx ny">import openai_function<br><br>@openai_functiondef sum(a:int, b:int):<br/>  &quot;&quot;&quot;Sum description adds a + b&quot;&quot;&quot;</span></pre>'''
-    expected = '''<code>import openai_function<lb/><lb/>@openai_functiondef sum(a:int, b:int):<lb/> """Sum description adds a + b"""</code>'''
+    expected = '''<code>import openai_function<lb/><lb/>@openai_functiondef sum(a:int, b:int):<lb/>  """Sum description adds a + b"""</code>'''
     testresult = extract(medium_ssr, config=ZERO_CONFIG, output_format='xml')
     assert expected in testresult and 'quote' not in testresult
 

--- a/trafilatura/core.py
+++ b/trafilatura/core.py
@@ -27,7 +27,7 @@ from .htmlprocessing import (convert_tags, handle_textnode, process_node,
                              prune_unwanted_nodes, tree_cleaning)
 from .metadata import extract_metadata, Document
 from .settings import use_config, DEFAULT_CONFIG, TAG_CATALOG
-from .utils import is_image_file, load_html, normalize_unicode, trim, txttocsv
+from .utils import is_image_file, load_html, normalize_unicode, trim, txttocsv, CODE_SPACE
 from .xml import (build_json_output, build_xml_output, build_tei_output,
                   control_xml_output, remove_empty_elements, strip_double_tags, xmltotxt)
 from .xpaths import (BODY_XPATH, COMMENTS_XPATH, COMMENTS_DISCARD_XPATH, OVERALL_DISCARD_XPATH,
@@ -225,6 +225,13 @@ def handle_code_blocks(element):
     processed_element = deepcopy(element)
     for child in element.iter('*'):
         child.tag = 'done'
+
+    # encode code spaces differently to keep formatting
+    for child in processed_element.getchildren():
+        if child.text is not None:
+            child.text = child.text.replace(' ', CODE_SPACE)
+        if child.tail is not None:
+            child.tail = child.tail.replace(' ', CODE_SPACE)
     processed_element.tag = 'code'
     return processed_element
 

--- a/trafilatura/core.py
+++ b/trafilatura/core.py
@@ -208,7 +208,7 @@ def handle_lists(element, options):
 
 def get_code_block_element(element):
     # pip
-    if element.get('lang') is not None:
+    if element.get('lang') is not None or element.tag == 'code':
         return element
     # GitHub
     parent = element.getparent()
@@ -491,6 +491,13 @@ def recover_wild_text(tree, result_body, options, potential_tags=TAG_CATALOG):
         search_expr += '|.//div|.//lb|.//list'
     # prune
     search_tree = prune_unwanted_sections(tree, potential_tags, options)
+    # find hljs elements to detect that it's code
+    hljs_elems = search_tree.xpath("//span[starts-with(@class,'hljs')]")
+    if len(hljs_elems) > 0:
+        for e in hljs_elems:
+            parent = e.getparent().getparent()
+            if parent.tag == 'quote':
+                parent.tag = 'code'
     # decide if links are preserved
     if 'ref' not in potential_tags:
         strip_tags(search_tree, 'a', 'ref', 'span')

--- a/trafilatura/core.py
+++ b/trafilatura/core.py
@@ -206,36 +206,30 @@ def handle_lists(element, options):
     return None
 
 
-def get_code_block_element(element):
+def is_code_block_element(element):
     # pip
     if element.get('lang') is not None or element.tag == 'code':
-        return element
+        return True
     # GitHub
     parent = element.getparent()
     if parent is not None and 'highlight' in parent.get('class', default=''):
-        return element
+        return True
     # highlightjs
     code = element.find('code')
     if code is not None and len(element.getchildren()) == 1:
-        return code
-    return None
+        return True
+    return False
 
 
-def handle_code_blocks(element, code):
-    processed_element = Element('code')
-    for child in element.iter('*'):
-        if child.tag == 'lb':
-            child.text = '\n'
-        child.tag = 'done'
-    processed_element.text = ''.join(code.itertext())
-    return processed_element
+def handle_code_blocks(element):
+    element.tag = 'code'
+    return element
 
 
 def handle_quotes(element, options):
     '''Process quotes elements'''
-    code = get_code_block_element(element)
-    if code is not None:
-        return handle_code_blocks(element, code)
+    if is_code_block_element(element):
+        return handle_code_blocks(element)
 
     processed_element = Element(element.tag)
     for child in element.iter('*'):
@@ -255,7 +249,7 @@ def handle_other_elements(element, potential_tags, options):
     '''Handle diverse or unknown elements in the scope of relevant tags'''
     # handle w3schools code
     if element.tag == 'div' and 'w3-code' in element.get('class', default=''):
-        return handle_code_blocks(element, element)
+        return handle_code_blocks(element)
     # delete unwanted
     if element.tag not in potential_tags:
         if element.tag != 'done':
@@ -809,7 +803,8 @@ def determine_returnstring(document, output_format, include_formatting, tei_vali
         for element in document.body.iter('*'):
             if element.tag != 'graphic' and len(element) == 0 and not element.text and not element.tail:
                 parent = element.getparent()
-                if parent is not None:
+                # do not remove elements inside <code> to preserve formatting
+                if parent is not None and parent.tag != 'code':
                     parent.remove(element)
         # build output trees
         strip_double_tags(document.body)

--- a/trafilatura/core.py
+++ b/trafilatura/core.py
@@ -491,7 +491,7 @@ def recover_wild_text(tree, result_body, options, potential_tags=TAG_CATALOG):
         search_expr += '|.//div|.//lb|.//list'
     # prune
     search_tree = prune_unwanted_sections(tree, potential_tags, options)
-    # find hljs elements to detect that it's code
+    # find hljs elements to detect that if it's code
     hljs_elems = search_tree.xpath("//span[starts-with(@class,'hljs')]")
     if len(hljs_elems) > 0:
         for e in hljs_elems:

--- a/trafilatura/core.py
+++ b/trafilatura/core.py
@@ -222,8 +222,11 @@ def is_code_block_element(element):
 
 
 def handle_code_blocks(element):
-    element.tag = 'code'
-    return element
+    processed_element = deepcopy(element)
+    for child in element.iter('*'):
+        child.tag = 'done'
+    processed_element.tag = 'code'
+    return processed_element
 
 
 def handle_quotes(element, options):

--- a/trafilatura/core.py
+++ b/trafilatura/core.py
@@ -22,17 +22,19 @@ from .external import justext_rescue, sanitize_tree, SANITIZED_XPATH, try_readab
 from .filters import (LANGID_FLAG, check_html_lang, duplicate_test,
                       language_filter, text_chars_test)
 from .hashing import content_fingerprint
-from .htmlprocessing import (convert_tags, handle_textnode, process_node,
-                             delete_by_link_density, link_density_test_tables,
-                             prune_unwanted_nodes, tree_cleaning)
-from .metadata import extract_metadata, Document
-from .settings import use_config, DEFAULT_CONFIG, TAG_CATALOG
-from .utils import is_image_file, load_html, normalize_unicode, trim, txttocsv, CODE_SPACE
-from .xml import (build_json_output, build_xml_output, build_tei_output,
-                  control_xml_output, remove_empty_elements, strip_double_tags, xmltotxt)
-from .xpaths import (BODY_XPATH, COMMENTS_XPATH, COMMENTS_DISCARD_XPATH, OVERALL_DISCARD_XPATH,
-                     TEASER_DISCARD_XPATH, PAYWALL_DISCARD_XPATH, PRECISION_DISCARD_XPATH,
-                     DISCARD_IMAGE_ELEMENTS, REMOVE_COMMENTS_XPATH)
+from .htmlprocessing import (convert_tags, delete_by_link_density,
+                             handle_textnode, link_density_test_tables,
+                             process_node, prune_unwanted_nodes, tree_cleaning)
+from .metadata import Document, extract_metadata
+from .settings import DEFAULT_CONFIG, TAG_CATALOG, use_config
+from .utils import is_image_file, load_html, normalize_unicode, trim, txttocsv
+from .xml import (build_json_output, build_tei_output, build_xml_output,
+                  control_xml_output, remove_empty_elements, strip_double_tags,
+                  xmltotxt)
+from .xpaths import (BODY_XPATH, COMMENTS_DISCARD_XPATH, COMMENTS_XPATH,
+                     DISCARD_IMAGE_ELEMENTS, OVERALL_DISCARD_XPATH,
+                     PAYWALL_DISCARD_XPATH, PRECISION_DISCARD_XPATH,
+                     REMOVE_COMMENTS_XPATH, TEASER_DISCARD_XPATH)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -225,13 +227,6 @@ def handle_code_blocks(element):
     processed_element = deepcopy(element)
     for child in element.iter('*'):
         child.tag = 'done'
-
-    # encode code spaces differently to keep formatting
-    for child in processed_element.getchildren():
-        if child.text is not None:
-            child.text = child.text.replace(' ', CODE_SPACE)
-        if child.tail is not None:
-            child.tail = child.tail.replace(' ', CODE_SPACE)
     processed_element.tag = 'code'
     return processed_element
 

--- a/trafilatura/core.py
+++ b/trafilatura/core.py
@@ -495,13 +495,6 @@ def recover_wild_text(tree, result_body, options, potential_tags=TAG_CATALOG):
         search_expr += '|.//div|.//lb|.//list'
     # prune
     search_tree = prune_unwanted_sections(tree, potential_tags, options)
-    # find hljs elements to detect that if it's code
-    hljs_elems = search_tree.xpath("//span[starts-with(@class,'hljs')]")
-    if len(hljs_elems) > 0:
-        for e in hljs_elems:
-            parent = e.getparent().getparent()
-            if parent.tag == 'quote':
-                parent.tag = 'code'
     # decide if links are preserved
     if 'ref' not in potential_tags:
         strip_tags(search_tree, 'a', 'ref', 'span')

--- a/trafilatura/core.py
+++ b/trafilatura/core.py
@@ -207,6 +207,9 @@ def handle_lists(element, options):
 
 
 def get_code_block_element(element):
+    # pip
+    if element.get('lang') is not None:
+        return element
     # GitHub
     parent = element.getparent()
     if parent is not None and 'highlight' in parent.get('class', default=''):

--- a/trafilatura/htmlprocessing.py
+++ b/trafilatura/htmlprocessing.py
@@ -289,20 +289,28 @@ def convert_tags(tree, options, url=None):
             elem.tag = 'lb'
         # wbr
         # pre
-        elif elem.tag == 'pre':
-            children = elem.getchildren()
-            # pre with a single span is more likely to be code
-            if len(children) == 1 and children[0].tag == 'span':
+        #elif elem.tag == 'pre':
+        #    else:
+        #        elem.tag = 'quote'
+        # blockquote, q → quote
+        elif elem.tag in ('blockquote', 'pre', 'q'):
+            code_flag = False
+            if elem.tag == 'pre':
+                # detect if there could be code inside
+                children = elem.getchildren()
+                # pre with a single span is more likely to be code
+                if len(children) == 1 and children[0].tag == 'span':
+                    code_flag = True
+            # find hljs elements to detect if it's code
+            code_elems = elem.xpath(".//span[starts-with(@class,'hljs')]")
+            if code_elems:
+                code_flag = True
+                for subelem in code_elems:
+                    subelem.attrib.clear()
+            if code_flag:
                 elem.tag = 'code'
             else:
                 elem.tag = 'quote'
-        # blockquote, q → quote
-        elif elem.tag in ('blockquote', 'q'):
-            # find hljs elements to detect if it's code
-            if elem.xpath(".//span[starts-with(@class,'hljs')]"):
-                 elem.tag = 'code'
-            else:
-                 elem.tag = 'quote'
         # del | s | strike → <del rend="overstrike">
         elif elem.tag in ('del', 's', 'strike'):
             elem.tag = 'del'
@@ -344,7 +352,7 @@ def handle_textnode(element, options, comments_fix=True, preserve_spaces=False):
             element.tail = trim(element.tail)
     # filter content
     # or not re.search(r'\w', element.text):  # text_content()?
-    if not element.text or textfilter(element) is True:  
+    if not element.text or textfilter(element) is True:
         return None
     if options.dedup and duplicate_test(element, options.config) is True:
         return None

--- a/trafilatura/htmlprocessing.py
+++ b/trafilatura/htmlprocessing.py
@@ -299,8 +299,16 @@ def convert_tags(tree, options, url=None):
         elif elem.tag in ('br', 'hr'):
             elem.tag = 'lb'
         # wbr
-        # blockquote, pre, q → quote
-        elif elem.tag in ('blockquote', 'pre', 'q'):
+        # pre
+        elif elem.tag == 'pre':
+            children = elem.getchildren()
+            # pre with a single span is more likely to be code
+            if len(children) == 1 and children[0].tag == 'span':
+                elem.tag = 'code'
+            else:
+                elem.tag = 'quote'
+        # blockquote, q → quote
+        elif elem.tag in ('blockquote', 'q'):
             elem.tag = 'quote'
         # del | s | strike → <del rend="overstrike">
         elif elem.tag in ('del', 's', 'strike'):

--- a/trafilatura/htmlprocessing.py
+++ b/trafilatura/htmlprocessing.py
@@ -309,7 +309,11 @@ def convert_tags(tree, options, url=None):
                 elem.tag = 'quote'
         # blockquote, q → quote
         elif elem.tag in ('blockquote', 'q'):
-            elem.tag = 'quote'
+            # find hljs elements to detect if it's code
+            if elem.xpath(".//span[starts-with(@class,'hljs')]"):
+                 elem.tag = 'code'
+            else:
+                 elem.tag = 'quote'
         # del | s | strike → <del rend="overstrike">
         elif elem.tag in ('del', 's', 'strike'):
             elem.tag = 'del'

--- a/trafilatura/utils.py
+++ b/trafilatura/utils.py
@@ -76,6 +76,7 @@ AUTHOR_REMOVE_HTML = re.compile(r'<[^>]+>')
 CLEAN_META_TAGS = re.compile(r'["\']')
 
 STRIP_EXTENSION = re.compile(r"\.[^/?#]{2,63}$")
+CODE_SPACE = ';cs;'
 
 
 def handle_compressed_file(filecontent):
@@ -270,6 +271,8 @@ def line_processing(line):
     # remove newlines that are not related to punctuation or markup
     # remove non-printable chars and normalize space characters (including Unicode spaces)
     line = trim(remove_control_characters(LINES_TRIMMING.sub(r' ', line)))
+    # replace unique code spaces with regular space
+    line = line.replace(CODE_SPACE, ' ')
     # prune empty lines
     if all(map(str.isspace, line)):
         line = None

--- a/trafilatura/utils.py
+++ b/trafilatura/utils.py
@@ -267,12 +267,11 @@ def line_processing(line):
     '''Remove HTML space entities, then discard incompatible unicode
        and invalid XML characters on line level'''
     # spacing HTML entities: https://www.w3.org/MarkUp/html-spec/html-spec_13.html
-    line = line.replace('&#13;', '\r').replace('&#10;', '\n').replace('&nbsp;', '\u00A0')
+    # unique code spaces
+    line = line.replace('&#13;', '\r').replace('&#10;', '\n').replace('&nbsp;', '\u00A0').replace(';cs;', ' ')
     # remove newlines that are not related to punctuation or markup
     # remove non-printable chars and normalize space characters (including Unicode spaces)
     line = trim(remove_control_characters(LINES_TRIMMING.sub(r' ', line)))
-    # replace unique code spaces with regular space
-    line = line.replace(CODE_SPACE, ' ')
     # prune empty lines
     if all(map(str.isspace, line)):
         line = None

--- a/trafilatura/utils.py
+++ b/trafilatura/utils.py
@@ -73,7 +73,6 @@ AUTHOR_REMOVE_HTML = re.compile(r'<[^>]+>')
 CLEAN_META_TAGS = re.compile(r'["\']')
 
 STRIP_EXTENSION = re.compile(r"\.[^/?#]{2,63}$")
-CODE_SPACE = ';cs;'
 
 
 def handle_compressed_file(filecontent):

--- a/trafilatura/xml.py
+++ b/trafilatura/xml.py
@@ -68,7 +68,8 @@ def remove_empty_elements(tree):
         if len(element) == 0 and text_chars_test(element.text) is False and text_chars_test(element.tail) is False:
             parent = element.getparent()
             # not root element or element which is naturally empty
-            if parent is not None and element.tag != "graphic":
+            # do not remove elements inside <code> to preserve formatting
+            if parent is not None and element.tag != "graphic" and parent.tag != 'code':
                 element.getparent().remove(element)
     return tree
 

--- a/trafilatura/xpaths.py
+++ b/trafilatura/xpaths.py
@@ -144,7 +144,7 @@ OVERALL_DISCARD_XPATH = [
     or contains(@class, "message-container") or contains(@id, "message_container")
     or contains(@class, "yin") or contains(@class, "zlylin") or
     contains(@class, "xg1") or contains(@id, "bmdh")
-    or @data-lp-replacement-content][not(starts-with(@class,'hljs'))]''',
+    or @data-lp-replacement-content]''',
 
     # comment debris + hidden parts
     '''.//*[@class="comments-title" or contains(@class, "comments-title") or

--- a/trafilatura/xpaths.py
+++ b/trafilatura/xpaths.py
@@ -144,7 +144,7 @@ OVERALL_DISCARD_XPATH = [
     or contains(@class, "message-container") or contains(@id, "message_container")
     or contains(@class, "yin") or contains(@class, "zlylin") or
     contains(@class, "xg1") or contains(@id, "bmdh")
-    or @data-lp-replacement-content]''',
+    or @data-lp-replacement-content][not(starts-with(@class,'hljs'))]''',
 
     # comment debris + hidden parts
     '''.//*[@class="comments-title" or contains(@class, "comments-title") or


### PR DESCRIPTION
This PR improves support in detecting and handling code snippets as follows:
* pypi.org snippets support (page example: https://pypi.org/project/openai-function-call/)
* Medium scraping with and without js enabled (page example: https://medium.com/@jxnlco/seamless-integration-with-openai-and-pydantic-a-powerful-duo-for-output-parsing-fcb1e616167b)
* Keep proper formatting which includes spaces and new lines for code snippets to preserve correctness of the syntax