### PR TITLE
Improve SEO by adding sitemap to sphinx docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -139,3 +139,5 @@ intersphinx_mapping = {
 
 html_baseurl = 'https://trafilatura.readthedocs.io/'
 sitemap_url_scheme = "{lang}latest/{link}"
+
+html_extra_path = ['robots.txt']

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -138,3 +138,4 @@ intersphinx_mapping = {
 }
 
 html_baseurl = 'https://trafilatura.readthedocs.io/'
+sitemap_url_scheme = "{lang}latest/{link}"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,7 +52,8 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
     'sphinx.ext.napoleon',
-    'sphinx.ext.viewcode'
+    'sphinx.ext.viewcode',
+    'sphinx_sitemap'
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -135,3 +136,5 @@ html_context = {
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
 }
+
+html_baseurl = 'https://trafilatura.readthedocs.io/'

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,3 +4,4 @@ pydata-sphinx-theme>=0.14.1
 docutils>=0.20.1
 # without version specifier
 trafilatura
+sphinx-sitemap

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+
+Sitemap: https://trafilatura.readthedocs.io/en/latest/sitemap.xml


### PR DESCRIPTION
This PR adds `sitemap.xml` to sphinx docs using sphinx-sitemap package. Including a sitemap improves SEO for the documentation site (source: [stackexchange](https://webmasters.stackexchange.com/questions/53287/do-all-pages-have-to-be-added-to-xml-sitemaps)).

Here is the generate sitemap file hosted on a mirror of the sphinx docs: https://trafilatura-epsilla.readthedocs.io/en/latest/sitemap.xml

Here is the [corresponding link](https://trafilatura.readthedocs.io/en/latest/sitemap.xml) in existing docs: it reports HTTP 404.