### PR TITLE
add_raw_html_prop

### DIFF
--- a/trafilatura/core.py
+++ b/trafilatura/core.py
@@ -15,6 +15,7 @@ from copy import deepcopy
 
 from lxml.etree import Element, SubElement, strip_elements, strip_tags
 from lxml.html import tostring
+from lxml import etree
 
 # own
 from .external import (SANITIZED_XPATH, justext_rescue, sanitize_tree,
@@ -971,7 +972,8 @@ def bare_extraction(filecontent, url=None, no_fallback=False,  # fast=False,
 
         # extract content
         postbody, temp_text, len_text = extract_content(cleaned_tree, options)
-
+        document.raw_html = etree.tostring(postbody, encoding="utf-8").decode("utf-8")
+        
         # compare if necessary
         if no_fallback is False:
             postbody, temp_text, len_text = compare_extraction(cleaned_tree_backup, tree_backup_1, url, postbody, temp_text, len_text, options)

--- a/trafilatura/metadata.py
+++ b/trafilatura/metadata.py
@@ -29,7 +29,7 @@ class Document:
     'title', 'author', 'url', 'hostname', 'description', 'sitename',
     'date', 'categories', 'tags', 'fingerprint', 'id', 'license',
     'body', 'comments', 'commentsbody', 'raw_text', 'text',
-    'language', 'image', 'pagetype'  # 'locale'?
+    'language', 'image', 'pagetype', 'raw_html'  # 'locale'?
     ]
     # consider dataclasses for Python 3.7+
     def __init__(self):


### PR DESCRIPTION
The main content extraction capability of "trafilatura" is great, 
but it is a waste that the final output is text. 
The raw_html property has been modified to return the HTML after the main content has been extracted.