### PR TITLE
Handle changed behaviour of `lxml` `addnext` method

### DIFF
--- a/tests/xml_tei_tests.py
+++ b/tests/xml_tei_tests.py
@@ -316,9 +316,9 @@ def test_ab_with_p_parent_resolved():
     </TEI>"""
     )
     cleaned = check_tei(xml_doc, "fake_url")
-    result = [(elem.tag, elem.text, elem.tail) for elem in xml_doc.iter(["p", "ab"])]
+    result = [(elem.tag, elem.text, elem.tail if elem.tail is None else elem.tail.strip()) for elem in xml_doc.iter(["p", "ab"])]
     assert result == [
-        ("p", "text1", None),
+        ("p", "text1", ''),
         ("ab", "text2", None),
         ("p", "text3", None),
         ("ab", "text4", None),
@@ -339,10 +339,10 @@ def test_ab_with_p_parent_resolved():
     </TEI>"""
     )
     cleaned = check_tei(xml_doc, "fake_url")
-    result = [(elem.tag, elem.text, elem.tail) for elem in xml_doc.iter(["p", "ab"])]
+    result = [(elem.tag, elem.text, elem.tail if elem.tail is None else elem.tail.strip()) for elem in xml_doc.iter(["p", "ab"])]
     assert result == [
-        ("p", "text0", None),
-        ("ab", "text1", None),
+        ("p", "text0", ''),
+        ("ab", "text1", ''),
         ("p", None, None),
         ("ab", "text3", None),
         ("p", "text4", None),

--- a/tests/xml_tei_tests.py
+++ b/tests/xml_tei_tests.py
@@ -318,7 +318,7 @@ def test_ab_with_p_parent_resolved():
     cleaned = check_tei(xml_doc, "fake_url")
     result = [(elem.tag, elem.text, elem.tail if elem.tail is None else elem.tail.strip()) for elem in xml_doc.iter(["p", "ab"])]
     assert result == [
-        ("p", "text1", ''),
+        ("p", "text1", ""),
         ("ab", "text2", None),
         ("p", "text3", None),
         ("ab", "text4", None),
@@ -341,8 +341,8 @@ def test_ab_with_p_parent_resolved():
     cleaned = check_tei(xml_doc, "fake_url")
     result = [(elem.tag, elem.text, elem.tail if elem.tail is None else elem.tail.strip()) for elem in xml_doc.iter(["p", "ab"])]
     assert result == [
-        ("p", "text0", ''),
-        ("ab", "text1", ''),
+        ("p", "text0", ""),
+        ("ab", "text1", ""),
         ("p", None, None),
         ("ab", "text3", None),
         ("p", "text4", None),

--- a/trafilatura/xml.py
+++ b/trafilatura/xml.py
@@ -494,13 +494,12 @@ def _move_element_one_level_up(element):
     parent = element.getparent()
     new_elem = Element("p")
     new_elem.extend(sibling for sibling in element.itersiblings())
-
-    parent.addnext(element)
-
+    grand_parent= parent.getparent()
+    grand_parent.insert(grand_parent.index(parent)+1, element)
     if element.tail is not None and element.tail.strip():
         new_elem.text = element.tail.strip()
         element.tail = None
     if len(new_elem) != 0 or new_elem.text:
-        element.addnext(new_elem)
+        grand_parent.insert(grand_parent.index(element)+1, new_elem)
     if len(parent) == 0 and parent.text is None:
-        parent.getparent().remove(parent)
+        grand_parent.remove(parent)

--- a/trafilatura/xml.py
+++ b/trafilatura/xml.py
@@ -246,7 +246,7 @@ def replace_element_text(element, include_formatting):
 def merge_with_parent(element, include_formatting=False):
     '''Merge element with its parent and convert formatting to markdown.'''
     parent = element.getparent()
-    if not parent:
+    if parent is None:
         return
 
     full_text = replace_element_text(element, include_formatting)
@@ -491,18 +491,28 @@ def _wrap_unwanted_siblings_of_div(div_element):
 
 
 def _move_element_one_level_up(element):
+    """
+    Fix TEI compatibility issues by moving certain p-elems up in the XML tree.
+    There is always a n+2 nesting for p-elements with the minimal structure ./TEI/text/body/p
+    """
     parent = element.getparent()
+    grand_parent = parent.getparent()
+
     new_elem = Element("p")
     new_elem.extend(sibling for sibling in element.itersiblings())
-    grand_parent= parent.getparent()
-    grand_parent.insert(grand_parent.index(parent)+1, element)
-    if element.tail is not None and element.tail.strip():
+
+    grand_parent.insert(grand_parent.index(parent) + 1, element)
+
+    if element.tail and element.tail.strip():
         new_elem.text = element.tail.strip()
         element.tail = None
-    if parent.tail is not None and parent.tail.strip():
+
+    if parent.tail and parent.tail.strip():
         new_elem.tail = parent.tail.strip()
         parent.tail = None
+
     if len(new_elem) != 0 or new_elem.text or new_elem.tail:
-        grand_parent.insert(grand_parent.index(element)+1, new_elem)
+        grand_parent.insert(grand_parent.index(element) + 1, new_elem)
+
     if len(parent) == 0 and parent.text is None:
         grand_parent.remove(parent)

--- a/trafilatura/xml.py
+++ b/trafilatura/xml.py
@@ -499,7 +499,10 @@ def _move_element_one_level_up(element):
     if element.tail is not None and element.tail.strip():
         new_elem.text = element.tail.strip()
         element.tail = None
-    if len(new_elem) != 0 or new_elem.text:
+    if parent.tail is not None and parent.tail.strip():
+        new_elem.tail = parent.tail.strip()
+        parent.tail = None
+    if len(new_elem) != 0 or new_elem.text or new_elem.tail:
         grand_parent.insert(grand_parent.index(element)+1, new_elem)
     if len(parent) == 0 and parent.text is None:
         grand_parent.remove(parent)


### PR DESCRIPTION
I removed the two usages of `addnext` and replaced them by `insert`. The code is maybe a bit harder to read now, but I thought this would be easier than to check the `lxml` version or how tails are handled by the `addnext` method. 

I had to adjust two test cases, since some elements now have whitespace instead of `None` as tail. However, I thought this to be an acceptable change in behaviour.

I tested the changes with `lxml==4.9.4` and `lxml==5.1.0` and it works with both versions.