### PR TITLE
Fixed unwanted content in some websites

### DIFF
--- a/trafilatura/xpaths.py
+++ b/trafilatura/xpaths.py
@@ -154,7 +154,7 @@ OVERALL_DISCARD_XPATH = [XPath(x) for x in (
     # comment debris + hidden parts
     '''.//*[@class="comments-title" or contains(@class, "comments-title") or
     contains(@class, "nocomments") or starts-with(@id, "reply-") or starts-with(@class, "reply-") or
-    contains(@class, "-reply-") or contains(@class, "message") or contains(@id, "reader-comments")
+    contains(@class, "-reply-") or contains(@class, "message") or contains(@id, "-comments") or contains(@class, "-comments")
     or contains(@id, "akismet") or contains(@class, "akismet") or
     starts-with(@class, "hide-") or contains(@class, "hide-print") or contains(@id, "hidden")
     or contains(@style, "hidden") or contains(@hidden, "hidden") or contains(@class, "noprint")

--- a/trafilatura/xpaths.py
+++ b/trafilatura/xpaths.py
@@ -16,7 +16,7 @@ BODY_XPATH = [XPath(x) for x in (
     contains(@class, "post-content") or contains(@class, "post_content") or
     contains(@class, "postcontent") or contains(@class, "postContent") or
     contains(@class, "article-text") or contains(@class, "articletext") or contains(@class, "articleText")
-    or contains(@id, "entry-content") or contains(@class, "-article") or
+    or contains(@id, "entry-content") or
     contains(@class, "entry-content") or contains(@id, "article-content") or
     contains(@class, "article-content") or contains(@id, "article__content") or
     contains(@class, "article__content") or contains(@id, "article-body") or

--- a/trafilatura/xpaths.py
+++ b/trafilatura/xpaths.py
@@ -16,7 +16,7 @@ BODY_XPATH = [XPath(x) for x in (
     contains(@class, "post-content") or contains(@class, "post_content") or
     contains(@class, "postcontent") or contains(@class, "postContent") or
     contains(@class, "article-text") or contains(@class, "articletext") or contains(@class, "articleText")
-    or contains(@id, "entry-content") or
+    or contains(@id, "entry-content") or contains(@class, "-article") or
     contains(@class, "entry-content") or contains(@id, "article-content") or
     contains(@class, "article-content") or contains(@id, "article__content") or
     contains(@class, "article__content") or contains(@id, "article-body") or

--- a/trafilatura/xpaths.py
+++ b/trafilatura/xpaths.py
@@ -154,7 +154,7 @@ OVERALL_DISCARD_XPATH = [XPath(x) for x in (
     # comment debris + hidden parts
     '''.//*[@class="comments-title" or contains(@class, "comments-title") or
     contains(@class, "nocomments") or starts-with(@id, "reply-") or starts-with(@class, "reply-") or
-    contains(@class, "-reply-") or contains(@class, "message") or contains(@id, "-comments") or contains(@class, "-comments")
+    contains(@class, "-reply-") or contains(@class, "message")
     or contains(@id, "akismet") or contains(@class, "akismet") or
     starts-with(@class, "hide-") or contains(@class, "hide-print") or contains(@id, "hidden")
     or contains(@style, "hidden") or contains(@hidden, "hidden") or contains(@class, "noprint")
@@ -188,6 +188,7 @@ PRECISION_DISCARD_XPATH = [XPath(x) for x in (
         or contains(@style, "border")
     ]''',
 )]
+# or contains(@id, "-comments") or contains(@class, "-comments")
 
 
 DISCARD_IMAGE_ELEMENTS = [XPath(

--- a/trafilatura/xpaths.py
+++ b/trafilatura/xpaths.py
@@ -149,7 +149,7 @@ OVERALL_DISCARD_XPATH = [XPath(x) for x in (
     or contains(@class, "message-container") or contains(@id, "message_container")
     or contains(@class, "yin") or contains(@class, "zlylin") or
     contains(@class, "xg1") or contains(@id, "bmdh")
-    or @data-lp-replacement-content or data-testid]''',
+    or @data-lp-replacement-content or @data-testid]''',
 
     # comment debris + hidden parts
     '''.//*[@class="comments-title" or contains(@class, "comments-title") or

--- a/trafilatura/xpaths.py
+++ b/trafilatura/xpaths.py
@@ -39,7 +39,7 @@ BODY_XPATH = [XPath(x) for x in (
     contains(@class, 'main-column') or contains(@class, 'wpb_text_column') or
     starts-with(@id, 'primary') or starts-with(@class, 'article ') or @class="text" or
     @id="article" or @class="cell" or @id="story" or @class="story" or
-    contains(@class, "story-body") or contains(@class, "field-body") or
+    contains(@class, "story-body") or contains(@id, "story-body") or contains(@class, "field-body") or
     contains(translate(@class, "FULTEX","fultex"), "fulltext")
     or @role='article'])[1]""",
     '''(.//*[(self::article or self::div or self::main or self::section)][
@@ -144,15 +144,17 @@ OVERALL_DISCARD_XPATH = [XPath(x) for x in (
     or contains(@class, "obfuscated") or contains(@class, "blurred")
     or contains(@class, " ad ")
     or contains(@class, "next-post")
+    or contains(@class, "related-stories") or contains(@class, "most-popular")
+    or contains(@class, "mol-factbox") or starts-with(@class, "ZendeskForm")
     or contains(@class, "message-container") or contains(@id, "message_container")
     or contains(@class, "yin") or contains(@class, "zlylin") or
     contains(@class, "xg1") or contains(@id, "bmdh")
-    or @data-lp-replacement-content]''',
+    or @data-lp-replacement-content or data-testid]''',
 
     # comment debris + hidden parts
     '''.//*[@class="comments-title" or contains(@class, "comments-title") or
     contains(@class, "nocomments") or starts-with(@id, "reply-") or starts-with(@class, "reply-") or
-    contains(@class, "-reply-") or contains(@class, "message")
+    contains(@class, "-reply-") or contains(@class, "message") or contains(@id, "reader-comments")
     or contains(@id, "akismet") or contains(@class, "akismet") or
     starts-with(@class, "hide-") or contains(@class, "hide-print") or contains(@id, "hidden")
     or contains(@style, "hidden") or contains(@hidden, "hidden") or contains(@class, "noprint")

--- a/trafilatura/xpaths.py
+++ b/trafilatura/xpaths.py
@@ -14,7 +14,7 @@ BODY_XPATH = [XPath(x) for x in (
     contains(@class, "post-text") or contains(@class, "post_text") or
     contains(@class, "post-body") or contains(@class, "post-entry") or contains(@class, "postentry") or
     contains(@class, "post-content") or contains(@class, "post_content") or
-    contains(@class, "postcontent") or contains(@class, "postContent") or
+    contains(@class, "postcontent") or contains(@class, "postContent") or contains(@class, "post_inner_wrapper") or
     contains(@class, "article-text") or contains(@class, "articletext") or contains(@class, "articleText")
     or contains(@id, "entry-content") or
     contains(@class, "entry-content") or contains(@id, "article-content") or

--- a/trafilatura/xpaths.py
+++ b/trafilatura/xpaths.py
@@ -158,7 +158,7 @@ OVERALL_DISCARD_XPATH = [XPath(x) for x in (
     or contains(@id, "akismet") or contains(@class, "akismet") or
     starts-with(@class, "hide-") or contains(@class, "hide-print") or contains(@id, "hidden")
     or contains(@style, "hidden") or contains(@hidden, "hidden") or contains(@class, "noprint")
-    or contains(@style, "display:none") or contains(@class, " hidden") or @aria-hidden="true"
+    or contains(@style, "display:none") or contains(@style, "display: none") or contains(@class, " hidden") or @aria-hidden="true"
     or contains(@class, "notloaded")]''',
 )]
 # conflicts:


### PR DESCRIPTION
Hey @adbar,

I did a check in the majors Australian websites and I added some classes and ids to the xpaths.py to avoid get unwanted content.

Canberra Times: (It was getting the newsletter box)
https://urlis.net/jw9sm5d2

The Australian (It was getting the related stories and most popular stories)
https://urlis.net/69cnu4ze

Courier Mail (It was getting an Amp box in the bottom)
https://urlis.net/qeuknv7n

Daily Mail (It was getting an 'exclusive' box and the comments)
https://urlis.net/z6gmds29

AFR (It was getting the author description in the bottom of the article)
https://urlis.net/ms64hmi5

ABC (It was getting a form in the bottom)
https://urlis.net/2yakvo39

The independent (it was showing comments)
https://urlis.net/rx3wq49x

Onya Magazine (It was getting the siderbar content instead of body)
https://urlis.net/m5mdzetf

Thank you.
