### PR TITLE
Fixed Extraction when Meta tag has an empty content

### DIFF
--- a/tests/metadata_tests.py
+++ b/tests/metadata_tests.py
@@ -26,7 +26,7 @@ def test_titles():
     # too short/empty
     metadata = extract_metadata('<html><body><h3 class="title">T</h3><h3 id="title"></h3></body></html>')
     assert metadata.title is None
-	metadata = extract_metadata('<html><head><title>Test Title</title><meta property="og:title" content=" " /></head><body><h1>First</h1></body></html>')
+    metadata = extract_metadata('<html><head><title>Test Title</title><meta property="og:title" content=" " /></head><body><h1>First</h1></body></html>')
     assert metadata.title == 'First'
     metadata = extract_metadata('<html><head><title>Test Title</title><meta name="title" content=" " /></head><body><h1>First</h1></body></html>')
     assert metadata.title == 'First'

--- a/trafilatura/metadata.py
+++ b/trafilatura/metadata.py
@@ -163,7 +163,7 @@ def extract_opengraph(tree):
     # detect OpenGraph schema
     for elem in tree.xpath('.//head/meta[starts-with(@property, "og:")]'):
         # safeguard
-        if not elem.get('content'):
+        if not elem.get('content') or len(trim(elem.get('content'))) == 0:
             continue
         # site name
         if elem.get('property') == 'og:site_name':
@@ -212,7 +212,7 @@ def examine_meta(tree):
     # skim through meta tags
     for elem in tree.iterfind('.//head/meta[@content]'):
         # content
-        if not elem.get('content'):
+        if not elem.get('content') or len(trim(elem.get('content'))) == 0:
             continue
         content_attr = HTML_STRIP_TAG.sub('', elem.get('content'))
         # image info

--- a/trafilatura/metadata.py
+++ b/trafilatura/metadata.py
@@ -163,7 +163,7 @@ def extract_opengraph(tree):
     # detect OpenGraph schema
     for elem in tree.xpath('.//head/meta[starts-with(@property, "og:")]'):
         # safeguard
-        if not elem.get('content') or len(trim(elem.get('content'))) == 0:
+        if not elem.get('content') or elem.get('content').isspace():
             continue
         # site name
         if elem.get('property') == 'og:site_name':
@@ -212,7 +212,7 @@ def examine_meta(tree):
     # skim through meta tags
     for elem in tree.iterfind('.//head/meta[@content]'):
         # content
-        if not elem.get('content') or len(trim(elem.get('content'))) == 0:
+        if not elem.get('content') or elem.get('content').isspace():
             continue
         content_attr = HTML_STRIP_TAG.sub('', elem.get('content'))
         # image info


### PR DESCRIPTION
Hey @adbar,

I had a few cases that the below meta tags are empty, and when it happen the extraction stops to work.

```html
   <meta name="title" content=" " />
   <meta property="og:title" content=" " />
   <meta name="twitter:title" content=" " />
```
I checked and the line below is checking for None before trying to get the correct title, but it never happens, because the title is ' ' in this line.
https://github.com/adbar/trafilatura/blob/fb3e1744d8d8840c05233c4f61460b9f3b375847/trafilatura/metadata.py#L507

Evan on json parse it is checking for None but the current title is ' ':
https://github.com/adbar/trafilatura/blob/fb3e1744d8d8840c05233c4f61460b9f3b375847/trafilatura/json_metadata.py#L109

And then this function convert the the title ' ' to none:
https://github.com/adbar/trafilatura/blob/fb3e1744d8d8840c05233c4f61460b9f3b375847/trafilatura/metadata.py#L573

And then it will fail here:
https://github.com/adbar/trafilatura/blob/fb3e1744d8d8840c05233c4f61460b9f3b375847/trafilatura/core.py#L929

This is an example of the problem:

[Example](https://t.ly/9szQB)

I run the the tests and comparison_small.py and it appears to be the same.

Thanks.