### PR TITLE
Simple content scoring prototype

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+	// Use IntelliSense to learn about possible attributes.
+	// Hover to view descriptions of existing attributes.
+	// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"name": "Python Debugger: Current File",
+			"type": "debugpy",
+			"request": "launch",
+			"program": "${file}",
+			"console": "integratedTerminal"
+		}
+	]
+}

--- a/tests/eval-requirements.txt
+++ b/tests/eval-requirements.txt
@@ -1,4 +1,4 @@
-trafilatura==1.8.1
+# trafilatura==1.8.1
 
 # alternatives
 beautifulsoup4==4.12.3

--- a/tests/scoring_small.py
+++ b/tests/scoring_small.py
@@ -1,0 +1,577 @@
+"""
+Compare extraction results with other libraries of the same kind.
+"""
+
+import logging
+import os
+import re
+import statistics
+import sys
+import time
+
+from lxml import html
+from trafilatura.readability_utils import is_probably_readerable
+from trafilatura.scoring import unique_words_html, unique_words_markdown
+
+try:
+    from cchardet import detect
+except ImportError:
+    from charset_normalizer import detect
+
+# import justext
+# from readability import Document
+
+from evaldata import EVAL_PAGES  # ADDITIONAL_PAGES as EVAL_PAGES
+
+
+from trafilatura import extract
+
+try:
+    from trafilatura import baseline, html2txt
+except ImportError:
+    print("Cannot import baseline, using simple version")
+    baseline = None
+    html2txt = None
+# from trafilatura.htmlprocessing import prune_html
+# from trafilatura.external import ReadabilityDocument, custom_justext, jt_stoplist_init
+# from trafilatura.external import try_readability, sanitize_tree, custom_justext, jt_stoplist_init
+# from trafilatura.utils import load_html, sanitize
+# from trafilatura.xml import xmltotxt
+
+logging.basicConfig(stream=sys.stdout, level=logging.WARNING)
+
+TEST_DIR = os.path.abspath(os.path.dirname(__file__))
+
+## logging.basicConfig(stream=sys.stdout, level=logging.WARNING)
+
+# JT_STOPLIST = jt_stoplist_init()
+
+
+def trim(string):
+    """Remove unnecessary spaces within a text string"""
+    if string is not None:
+        # delete newlines that are not related to punctuation or markup
+        # string = re.sub(r'(?<![p{P}>])\n', ' ', string)
+        # proper trimming
+        string = " ".join(
+            re.split(r"\s+", string.strip(" \t\n\r"), flags=re.UNICODE | re.MULTILINE)
+        )
+        string = string.strip()
+    return string
+
+
+def load_document_binary(filename):
+    """load mock page from samples"""
+    mypath = os.path.join(TEST_DIR, "cache", filename)
+    if not os.path.isfile(mypath):
+        mypath = os.path.join(TEST_DIR, "eval", filename)
+    # if not os.path.isfile(mypath):
+    #    mypath = os.path.join(TEST_DIR, 'additional', filename)
+    with open(mypath, "rb") as inputf:
+        htmlstring = inputf.read()
+    return htmlstring
+
+
+def load_document_string(filename):
+    """load mock page from samples"""
+    mypath = os.path.join(TEST_DIR, "cache", filename)
+    if not os.path.isfile(mypath):
+        mypath = os.path.join(TEST_DIR, "eval", filename)
+    # if not os.path.isfile(mypath):
+    #    mypath = os.path.join(TEST_DIR, 'additional', filename)
+    try:
+        with open(mypath, "r", encoding="utf-8") as inputf:
+            htmlstring = inputf.read()
+    # encoding/windows fix for the tests
+    except UnicodeDecodeError:
+        # read as binary
+        with open(mypath, "rb") as inputf:
+            htmlbinary = inputf.read()
+        guessed_encoding = detect(htmlbinary)["encoding"]
+        if guessed_encoding is not None:
+            try:
+                htmlstring = htmlbinary.decode(guessed_encoding)
+            except UnicodeDecodeError:
+                htmlstring = htmlbinary
+        else:
+            print("Encoding error")
+    return htmlstring
+
+
+def run_html2txt(htmlstring):
+    if html2txt is not None:
+        return html2txt(htmlstring)
+    return ""
+
+
+def run_baseline_2(htmlstring):
+    """run bare text extraction within lxml"""
+    # binary/string as input tweak
+    try:
+        tree = html.fromstring(htmlstring)
+    except ValueError:
+        tree = html.fromstring(htmlstring.encode("utf8"))
+    result = None
+    # try json-ld
+    for elem in tree.xpath('//script[@type="application/ld+json"]'):
+        if elem.text and '"articleBody":' in elem.text:
+            mymatch = re.search(r'"articleBody":"(.+?)","', elem.text)
+            if mymatch:
+                result = mymatch.group(1)
+                result = result.replace('\\"', '"')
+                # result = trim(result)
+                break
+    if result is not None:
+        return result
+    # results = set()
+    resultlist = []
+    # iterate potentially relevant elements
+    for element in tree.iter(
+        "blockquote", "code", "p", "pre", "q"
+    ):  # 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'
+        # if element.tag in ('h1', 'h2', 'h3', 'h4', 'h5', 'h6'):
+        #    if not element.text or len(element.text) < 20:
+        #        continue
+        #    entry = element.text
+        # else:
+        entry = element.text_content()
+        # if entry not in results and len(entry) > 10:
+        resultlist.append(entry)
+        # results.add(entry)
+    # if nothing has been found
+    # if len(resultlist) < 1:
+    #    for element in tree.iter('b', 'em', 'i', 'strong'):
+    #        entry = element.text_content()
+    #        #if entry not in results: # and len(entry) > 15:
+    #        resultlist.append(entry)
+    #        #results.add(entry)
+    # if len(resultlist) == 0:
+    #    cleaned_tree = HTML_CLEANER.clean_html(tree)
+    #    for element in tree.iter('div'):
+    #        entry = element.text_content()
+    # if len(entry) > 15:
+    #        resultlist.append(entry)
+    #        #results.add(entry)
+    # print(len(resultlist))
+    result = "\n".join(resultlist)
+    # result = sanitize(result)
+    # print(result)
+    return result
+
+
+def run_baseline(htmlstring):
+    """run bare text extraction within lxml"""
+    if baseline is not None:
+        _, result, _ = baseline(htmlstring)
+        return result
+    return run_baseline_2(htmlstring)
+
+
+def run_trafilatura(htmlstring):
+    """run trafilatura (without fallback) on content"""
+    result = extract(
+        htmlstring,
+        no_fallback=True,
+        include_comments=False,
+        include_tables=True,
+        include_formatting=False,
+    )  # , deduplicate=False
+    return result
+
+
+# def run_justext(htmlstring):
+#    '''try with the generic algorithm justext'''
+#    valid = list()
+#    # paragraphs = justext.justext(htmlstring, stop_words, 50, 200, 0.1, 0.2, 0.5, 200, True)  # stop_words
+#    tree = load_html(htmlstring)
+#    try:
+#        paragraphs = custom_justext(tree, JT_STOPLIST)
+#        for paragraph in [p for p in paragraphs if not p.is_boilerplate]:
+#            valid.append(paragraph.text)
+#    except UnicodeDecodeError:
+#        pass
+#    return sanitize(' '.join(valid))
+
+
+def run_trafilatura_fallback(htmlstring):
+    """run trafilatura (with fallback) on content"""
+    result = extract(
+        htmlstring,
+        no_fallback=False,
+        include_comments=False,
+        include_tables=True,
+        include_formatting=False,
+    )  # , deduplicate=False
+    return result
+
+
+def run_trafilatura_precision(htmlstring):
+    """run trafilatura with preference for precision"""
+    result = extract(
+        htmlstring,
+        no_fallback=False,
+        favor_precision=True,
+        include_comments=False,
+        include_tables=True,
+        include_formatting=False,
+    )  # , deduplicate=False
+    return result
+
+
+def run_trafilatura_recall(htmlstring):
+    """run trafilatura with preference for recall"""
+    result = extract(
+        htmlstring,
+        no_fallback=False,
+        favor_recall=True,
+        include_comments=False,
+        include_tables=True,
+        include_formatting=False,
+    )  # , deduplicate=False
+    return result
+
+
+# def run_readability(htmlstring):
+#    '''try with the Python3 port of readability.js'''
+#    try:
+#        #doc = Document(htmlstring)
+#        cleaned_tree, text, _ = sanitize_tree(try_readability(load_html(htmlstring))
+#        return text
+#        #return xmltotxt(cleaned_tree, False, False)
+#    except Exception as err:
+#        print('Exception:', err)
+#        return ''
+
+
+def evaluate_result(result, item):
+    """evaluate result contents"""
+    true_positives = 0
+    false_negatives = 0
+    false_positives = 0
+    true_negatives = 0
+    # report if problematic
+    if len(item["with"]) == 0 or len(item["with"]) > 6:
+        print("counter", item)
+    if len(item["without"]) == 0 or len(item["without"]) > 6:
+        print("counter", item)
+    # internal report
+    # if result is None:
+    #    print('None', item['file'])
+    # elif type(result) is not str:
+    #    print('not str', item['file'])
+    # examine
+    if result is not None and isinstance(result, str):
+        # expected output
+        for to_include in item["with"]:
+            if to_include in result:
+                true_positives += 1
+            else:
+                false_negatives += 1
+        # unwanted output
+        for to_exclude in item["without"]:
+            if to_exclude in result:
+                false_positives += 1
+            else:
+                true_negatives += 1
+    # add up as bulk counts
+    else:
+        false_negatives += len(item["with"])
+        true_negatives += len(item["without"])
+
+    return true_positives, false_negatives, false_positives, true_negatives
+
+
+def calculate_scores(mydict):
+    """output weighted result score"""
+    tp, fn, fp, tn = (
+        mydict["true positives"],
+        mydict["false negatives"],
+        mydict["false positives"],
+        mydict["true negatives"],
+    )
+    precision = tp / (tp + fp)
+    recall = tp / (tp + fn)
+    accuracy = (tp + tn) / (tp + tn + fp + fn)
+    fscore = (2 * tp) / (2 * tp + fp + fn)  # 2*((precision*recall)/(precision+recall))
+    return precision, recall, accuracy, fscore
+
+
+template_dict = {
+    "true positives": 0,
+    "false positives": 0,
+    "true negatives": 0,
+    "false negatives": 0,
+    "time": 0,
+}
+(
+    everything,
+    nothing,
+    html2txt_result,
+    baseline_result,
+    trafilatura_result,
+    justext_result,
+    trafilatura_fallback_result,
+    trafilatura_precision,
+    trafilatura_recall,
+    readability_result,
+) = {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
+nothing.update(template_dict)
+everything.update(template_dict)
+html2txt_result.update(template_dict)
+baseline_result.update(template_dict)
+trafilatura_result.update(template_dict)
+justext_result.update(template_dict)
+trafilatura_fallback_result.update(template_dict)
+trafilatura_precision.update(template_dict)
+trafilatura_recall.update(template_dict)
+readability_result.update(template_dict)
+
+counts = {}
+i = 0
+
+for item in EVAL_PAGES:
+    if len(EVAL_PAGES[item]["file"]) == 0:
+        continue
+    # print(EVAL_PAGES[item]['file'])
+    htmlstring = load_document_binary(EVAL_PAGES[item]["file"])
+    if htmlstring is None:
+        continue
+
+    file = EVAL_PAGES[item]["file"]
+    counts[file] = {}
+
+    readability_result = is_probably_readerable(htmlstring)
+    counts[file]["readability"] = readability_result
+
+    counts[file]["html"] = unique_words_html(htmlstring)
+
+    # null hypotheses
+    tp, fn, fp, tn = evaluate_result("", EVAL_PAGES[item])
+    nothing["true positives"] += tp
+    nothing["false positives"] += fp
+    nothing["true negatives"] += tn
+    nothing["false negatives"] += fn
+    # tp, fn, fp, tn = evaluate_result(htmlstring, EVAL_PAGES[item])
+    # everything['true positives'] += tp
+    # everything['false positives'] += fp
+    # everything['true negatives'] += tn
+    # everything['false negatives'] += fn
+    # bare html2txt
+    # start = time.time()
+    # result = run_html2txt(htmlstring)
+    # html2txt_result['time'] += time.time() - start
+    # tp, fn, fp, tn = evaluate_result(result, EVAL_PAGES[item])
+    # html2txt_result['true positives'] += tp
+    # html2txt_result['false positives'] += fp
+    # html2txt_result['true negatives'] += tn
+    # html2txt_result['false negatives'] += fn
+    # bare lxml
+    # if baseline is not None:
+    start = time.time()
+    result = run_baseline(htmlstring)
+    baseline_result["time"] += time.time() - start
+    tp, fn, fp, tn = evaluate_result(result, EVAL_PAGES[item])
+    baseline_result["true positives"] += tp
+    baseline_result["false positives"] += fp
+    baseline_result["true negatives"] += tn
+    baseline_result["false negatives"] += fn
+    # trafilatura
+    start = time.time()
+    result = run_trafilatura(htmlstring)
+    trafilatura_result["time"] += time.time() - start
+    tp, fn, fp, tn = evaluate_result(result, EVAL_PAGES[item])
+    trafilatura_result["true positives"] += tp
+    trafilatura_result["false positives"] += fp
+    trafilatura_result["true negatives"] += tn
+    trafilatura_result["false negatives"] += fn
+    counts[file]["trafilatura"] = unique_words_markdown(result)
+
+    # justext / jparser
+    # start = time.time()
+    # result = run_justext(htmlstring)
+    # justext_result['time'] += time.time() - start
+    # tp, fn, fp, tn = evaluate_result(result, EVAL_PAGES[item])
+    # justext_result['true positives'] += tp
+    # justext_result['false positives'] += fp
+    # justext_result['true negatives'] += tn
+    # justext_result['false negatives'] += fn
+    # trafilatura + fallback
+    start = time.time()
+    result = run_trafilatura_fallback(htmlstring)
+    trafilatura_fallback_result["time"] += time.time() - start
+    tp, fn, fp, tn = evaluate_result(result, EVAL_PAGES[item])
+    trafilatura_fallback_result["true positives"] += tp
+    trafilatura_fallback_result["false positives"] += fp
+    trafilatura_fallback_result["true negatives"] += tn
+    trafilatura_fallback_result["false negatives"] += fn
+    # trafilatura + precision
+    # start = time.time()
+    # result = run_trafilatura_precision(htmlstring)
+    # trafilatura_precision['time'] += time.time() - start
+    # tp, fn, fp, tn = evaluate_result(result, EVAL_PAGES[item])
+    # trafilatura_precision['true positives'] += tp
+    # trafilatura_precision['false positives'] += fp
+    # trafilatura_precision['true negatives'] += tn
+    # trafilatura_precision['false negatives'] += fn
+    # trafilatura + recall
+    # start = time.time()
+    # result = run_trafilatura_recall(htmlstring)
+    # trafilatura_recall['time'] += time.time() - start
+    # tp, fn, fp, tn = evaluate_result(result, EVAL_PAGES[item])
+    # trafilatura_recall['true positives'] += tp
+    # trafilatura_recall['false positives'] += fp
+    # trafilatura_recall['true negatives'] += tn
+    # trafilatura_recall['false negatives'] += fn
+    # readability
+    # start = time.time()
+    # result = run_readability(htmlstring)
+    # readability_result['time'] += time.time() - start
+    # tp, fn, fp, tn = evaluate_result(result, EVAL_PAGES[item])
+    # readability_result['true positives'] += tp
+    # readability_result['false positives'] += fp
+    # readability_result['true negatives'] += tn
+    # readability_result['false negatives'] += fn
+    i += 1
+
+
+print("number of documents:", i)
+print("nothing")
+print(nothing)
+# print(calculate_f_score(nothing))
+# print('everything')
+# print(everything)
+# print("precision: %.3f recall: %.3f accuracy: %.3f f-score: %.3f" % (calculate_scores(everything)))
+
+# print('html2txt')
+# print(html2txt_result)
+# try:
+#    print("precision: %.3f recall: %.3f accuracy: %.3f f-score: %.3f" % (calculate_scores(html2txt_result)))
+# except ZeroDivisionError:
+#    pass
+
+print("baseline")
+print(baseline_result)
+try:
+    print(
+        "precision: %.3f recall: %.3f accuracy: %.3f f-score: %.3f"
+        % (calculate_scores(baseline_result))
+    )
+except ZeroDivisionError:
+    pass
+
+print("trafilatura")
+print(trafilatura_result)
+print("time diff.: %.2f" % (trafilatura_result["time"] / baseline_result["time"]))
+print(
+    "precision: %.3f recall: %.3f accuracy: %.3f f-score: %.3f"
+    % (calculate_scores(trafilatura_result))
+)
+
+# print('Justext')
+# print(justext_result)
+# print("time diff.: %.2f" % (justext_result['time'] / baseline_result['time']))
+# print("precision: %.3f recall: %.3f accuracy: %.3f f-score: %.3f" % (calculate_scores(justext_result)))
+
+print("trafilatura + fallback")
+print(trafilatura_fallback_result)
+print(
+    "time diff.: %.2f" % (trafilatura_fallback_result["time"] / baseline_result["time"])
+)
+print(
+    "precision: %.3f recall: %.3f accuracy: %.3f f-score: %.3f"
+    % (calculate_scores(trafilatura_fallback_result))
+)
+
+# print('trafilatura precision')
+# print(trafilatura_precision)
+# print("time diff.: %.2f" % (trafilatura_precision['time'] / baseline_result['time']))
+# print("precision: %.3f recall: %.3f accuracy: %.3f f-score: %.3f" % (calculate_scores(trafilatura_precision)))
+# print('trafilatura recall')
+# print(trafilatura_recall)
+# print("time diff.: %.2f" % (trafilatura_recall['time'] / baseline_result['time']))
+# print("precision: %.3f recall: %.3f accuracy: %.3f f-score: %.3f" % (calculate_scores(trafilatura_recall)))
+
+# print('readability')
+# print(readability_result)
+# print("time diff.: %.2f" % (readability_result['time'] / baseline_result['time']))
+# print("precision: %.3f recall: %.3f accuracy: %.3f f-score: %.3f" % (calculate_scores(readability_result)))
+
+
+def evaluate_scores(html_scores, content_scores):
+    print("Number of samples:", len(html_scores))
+
+    # Ratio of content score to HTML score
+    ratios = [
+        content / html if html != 0 else 0
+        for content, html in zip(content_scores, html_scores)
+    ]
+    avg_ratio = statistics.mean(ratios)
+    print("Average ratio of content score to HTML score:", avg_ratio)
+    print()
+
+    # Average difference between HTML score and content score
+    differences = [
+        abs(content - html) for content, html in zip(content_scores, html_scores)
+    ]
+    avg_diff = statistics.mean(differences)
+    print("Average difference between HTML score and content score:", avg_diff)
+    print()
+
+    # Percentage of files where content score is within different ranges of HTML score
+    ranges = [
+        (0.0, 0.5),
+        (0.5, 0.75),
+        (0.75, 1.0),
+        (1.0, 1.25),
+        (1.25, 1.5),
+        (1.5, float("inf")),
+    ]
+    range_counts = [0] * len(ranges)
+    range_percentages = [0] * len(ranges)
+
+    for content, html in zip(content_scores, html_scores):
+        if html == 0:
+            continue
+        ratio = content / html
+        for i, (lower, upper) in enumerate(ranges):
+            if lower <= ratio < upper:
+                range_counts[i] += 1
+                break
+
+    total_files = len(html_scores)
+    max_count = max(range_counts)
+    for i, count in enumerate(range_counts):
+        range_percentages[i] = (count / total_files) * 100
+
+    print("Range\t\tCount\tPercentage")
+    print("----------------------------")
+    for i, (lower, upper) in enumerate(ranges):
+        print(
+            f"{lower:.2f} - {upper:.2f}\t{range_counts[i]}\t{range_percentages[i]:.2f}%"
+        )
+
+    max_range_index = range_counts.index(max_count)
+    max_range = ranges[max_range_index]
+    print(f"\nThe range with the most examples is {max_range[0]} - {max_range[1]}")
+    print()
+
+
+# Calculate scores where is_probably_readerable is False
+html_scores = [
+    counts[item]["html"] for item in counts if not counts[item]["readability"]
+]
+content_scores = [
+    counts[item]["trafilatura"] for item in counts if not counts[item]["readability"]
+]
+
+print("is_probably_readerable is False")
+print("=================================")
+evaluate_scores(html_scores, content_scores)
+
+# All scores
+html_scores = [counts[item]["html"] for item in counts]
+content_scores = [counts[item]["trafilatura"] for item in counts]
+
+print("All scores")
+print("=================================")
+evaluate_scores(html_scores, content_scores)

--- a/trafilatura/readability_utils.py
+++ b/trafilatura/readability_utils.py
@@ -1,0 +1,73 @@
+import re
+from bs4 import BeautifulSoup
+
+REGEXPS = {
+    "unlikelyCandidates": re.compile(
+        r"-ad-|ai2html|banner|breadcrumbs|combx|comment|community|cover-wrap|disqus|extra|footer|gdpr|header|"
+        r"legends|menu|related|remark|replies|rss|shoutbox|sidebar|skyscraper|social|sponsor|supplemental|"
+        r"ad-break|agegate|pagination|pager|popup|yom-remote",
+        re.I,
+    ),
+    "okMaybeItsACandidate": re.compile(
+        r"and|article|body|column|content|main|shadow", re.I
+    ),
+}
+
+DISPLAY_NONE = re.compile(r"display:\s*none", re.I)
+
+
+def is_node_visible(node):
+    # This will handle visibility checking in the context of BeautifulSoup nodes
+    style = node.get("style", "")
+
+    is_hidden = DISPLAY_NONE.search(style) is not None or node.get("hidden") is not None
+    aria_hidden = node.get(
+        "aria-hidden"
+    ) == "true" and "fallback-image" not in node.get("class", "")
+    return not is_hidden and not aria_hidden
+
+
+def is_probably_readerable(doc, options=None):
+    if callable(options):
+        options = {"visibilityChecker": options}
+    elif options is None:
+        options = {}
+
+    default_options = {
+        "minScore": 20,
+        "minContentLength": 140,
+        "visibilityChecker": is_node_visible,
+    }
+    default_options.update(options)
+    options = default_options
+
+    soup = BeautifulSoup(doc, "html.parser")
+    nodes = soup.select("p, pre, article")
+
+    # Include divs that directly contain <br> tags
+    for node in soup.select("div > br"):
+        nodes.append(node.parent)
+
+    score = 0
+    for node in nodes:
+        if not options["visibilityChecker"](node):
+            continue
+
+        class_id_string = f"{node.get('class', '')} {node.get('id', '')}"
+        if REGEXPS["unlikelyCandidates"].search(class_id_string) and not REGEXPS[
+            "okMaybeItsACandidate"
+        ].search(class_id_string):
+            continue
+
+        if node.name == "li" and node.find("p"):
+            continue
+
+        text_content_length = len(node.get_text(strip=True))
+        if text_content_length < options["minContentLength"]:
+            continue
+
+        score += (text_content_length - options["minContentLength"]) ** 0.5
+        if score > options["minScore"]:
+            return True
+
+    return False

--- a/trafilatura/scoring.py
+++ b/trafilatura/scoring.py
@@ -1,0 +1,73 @@
+import re
+from bs4 import BeautifulSoup
+from trafilatura import html2txt
+
+MARKDOWN_FORMATTING_REGEX = re.compile(r"[\*\_\[\]\(\)\~\`\>\#\+\-\=\|\.!\?]")
+
+
+def remove_markdown_formatting(text):
+    """
+    Remove Markdown formatting from text
+    """
+    # Remove Markdown formatting
+    text = re.sub(MARKDOWN_FORMATTING_REGEX, "", text)
+
+    return text
+
+
+def unique_words(text):
+    """
+    Get unique words from text
+    """
+    # Split text into words and convert to set to get unique words
+    words = re.findall(r"\w+", text.lower())
+    unique_words = set(words)
+
+    return unique_words
+
+
+def unique_words_html(html):
+    """
+    Get unique words from HTML.
+    Remove semantic elements and relative links.
+    """
+    if not html:
+        return 0
+
+    soup = BeautifulSoup(html, "html.parser")
+
+    # Remove semantic elements
+    for elem in soup.find_all(["header", "nav", "footer"]):
+        elem.decompose()
+
+    # TODO delete relative links or absolute links to the same domain
+
+    plain = html2txt(str(soup))
+    plain = remove_markdown_formatting(plain)
+
+    return len(unique_words(plain))
+
+
+def unique_words_markdown(markdown):
+    """
+    Get unique word count from Markdown.
+    Remove markdown formatting.
+    """
+    if not markdown:
+        return 0
+
+    plain = remove_markdown_formatting(markdown)
+
+    return len(unique_words(plain))
+
+
+def confidence_score(html, markdown):
+    """
+    Calculate confidence score between HTML and Markdown
+    """
+    words_html = unique_words_html(html)
+    words_markdown = unique_words_markdown(markdown)
+
+    # TODO add multiple markdowns to compare and use the average count?
+
+    return float(words_markdown) / words_html if words_html > 0 else 0

--- a/trafilatura/scoring.py
+++ b/trafilatura/scoring.py
@@ -61,9 +61,9 @@ def unique_words_markdown(markdown):
     return len(unique_words(plain))
 
 
-def confidence_score(html, markdown):
+def content_score(html, markdown):
     """
-    Calculate confidence score between HTML and Markdown
+    Calculate content score between HTML and Markdown
     """
     words_html = unique_words_html(html)
     words_markdown = unique_words_markdown(markdown)


### PR DESCRIPTION
I implemented a small prototype as discussed in #572. It's super basic and I don't expect you to add it to the library, just wanted to show you some results and hear your opinion.

The `scoring.py` module contains the functions to count the unique words for a HTML and a markdown. The semantic elements (header, footer, nav) are removed, but other elements could be added based on class names or ids, or other tags link forms, inputs, etc. Links are not removed yet, but I think relative links are a good indicator that these are navigation elements and so they could also be removed I think. Absolute links or more specifically links to other hostnames should probably be kept.

The ratio `unique_words_html / unique_words_markdown` is then considered the content score. My assumption is the following:
- a score < 0.5 is bad because lot of content from the HTML is probably missing 
- a score between 0.5 and 1.0 is probably good because a lot of content was preserved
- a score > 1.0 is bad because it means the extraction returned more content than the HTML which probably means non-content related elements were extracted

I ported the Readability.js [`isProbablyReaderable` ](https://github.com/mozilla/readability/blob/main/Readability-readerable.js) to compare the results.My assumption is that a HTML file with `is_probably_readerable=False` should also have a low content score. 

The `scoring_small.py` module is a copy of `comparison_small.py`. I collect all unique words counts and calculate some statistics. Here are the results so far:

```
All scores
=================================
Number of samples: 750

Average ratio of content score to HTML score: 0.676667469420454
Average difference between HTML score and content score: 190.01466666666667

Range           Count   Percentage
----------------------------
0.00 - 0.50     172     22.93%
0.50 - 0.75     212     28.27%
0.75 - 1.00     327     43.60%
1.00 - 1.25     29      3.87%
1.25 - 1.50     0       0.00%
1.50 - inf      2       0.27%

The range with the most examples is 0.75 - 1.0


is_probably_readerable is False
=================================
Number of samples: 49

Average ratio of content score to HTML score: 0.4560205723986458
Average difference between HTML score and content score: 213.3877551020408

Range           Count   Percentage
----------------------------
0.00 - 0.50     24      48.98%
0.50 - 0.75     10      20.41%
0.75 - 1.00     5       10.20%
1.00 - 1.25     6       12.24%
1.25 - 1.50     0       0.00%
1.50 - inf      0       0.00%

The range with the most examples is 0.0 - 0.5
```

The current average content score across all files is 0.676 and for files which are not readerable (is_probably_readerable=False) it is 0.456. I assume the content score could be increased even more with more cleansing of the HTML. I will have to investigate the cases with a low content score and a score above 1.0 to see if they are actually bad.

Do you have any remark or ideas for improvements? Of course, these are all assumptions, so please don't hesitate to point out flaws in my logic or implementation.