### PR TITLE
Markdown table fixes

### DIFF
--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -888,7 +888,7 @@ def test_table_processing():
         htmlstring, no_fallback=True, output_format='xml', config=DEFAULT_CONFIG, include_links=True
     )
     result = processed.replace('\n', '').replace(' ', '')
-    assert """<table><rowspan="2"><cell>text<head>more_text</head></cell></row></table>""" in result
+    assert """<table><row><cell>text<head>more_text</head></cell></row></table>""" in result
 
     table_cell_w_text_and_child = html.fromstring(
         "<table><tr><td>text<lb/><p>more text</p></td></tr></table>"
@@ -979,7 +979,7 @@ def test_table_processing():
 </tr>
     </table></article></body></html>'''
     my_result = extract(htmlstring, no_fallback=True, output_format='xml', include_formatting=True, config=ZERO_CONFIG)
-    assert '''<row span="7">
+    assert '''<row>
         <cell>
           <hi>Present Tense</hi>
         </cell>

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -888,7 +888,7 @@ def test_table_processing():
         htmlstring, no_fallback=True, output_format='xml', config=DEFAULT_CONFIG, include_links=True
     )
     result = processed.replace('\n', '').replace(' ', '')
-    assert """<table><row><cell>text<head>more_text</head></cell></row></table>""" in result
+    assert """<table><rowspan="2"><cell>text<head>more_text</head></cell></row></table>""" in result
 
     table_cell_w_text_and_child = html.fromstring(
         "<table><tr><td>text<lb/><p>more text</p></td></tr></table>"
@@ -979,7 +979,7 @@ def test_table_processing():
 </tr>
     </table></article></body></html>'''
     my_result = extract(htmlstring, no_fallback=True, output_format='xml', include_formatting=True, config=ZERO_CONFIG)
-    assert '''<row>
+    assert '''<row span="7">
         <cell>
           <hi>Present Tense</hi>
         </cell>
@@ -1081,6 +1081,21 @@ def test_table_processing():
     # table headers in non-XML formats
     htmlstring = '<html><body><article><table><tr><th>head 1</th><th>head 2</th></tr><tr><td>1</td><td>2</td></tr></table></article></body></html>'
     assert "---|---|" in extract(htmlstring, no_fallback=True, output_format='txt', config=ZERO_CONFIG, include_tables=True)
+
+    # remove new lines in table cells in text format
+    htmlstring = '<html><body><article><table><tr><td>cell<br>1</td><td>cell<p>2</p></td></tr></table></article></body></html>'
+    result = extract(htmlstring, no_fallback=True, output_format='txt', config=ZERO_CONFIG, include_tables=True)
+    assert "cell 1 | cell 2 |" in result
+
+    # only one header row is allowed in text format
+    htmlstring = '<html><body><article><table><tr><th>a</th><th>b</th></tr><tr><th>c</th><th>d</th></tr></table></article></body></html>'
+    result = extract(htmlstring, no_fallback=True, output_format='txt', config=ZERO_CONFIG, include_tables=True)
+    assert result.count("---|") == 2
+
+    # handle colspan by appending columns in text format
+    htmlstring = '<html><body><article><table><tr><td colspan="2">a</td><td>b</td></tr><tr><td>c</td><td>d</td><td>e</td></tr></table></article></body></html>'
+    result = extract(htmlstring, no_fallback=True, output_format='txt', config=ZERO_CONFIG, include_tables=True)
+    assert "a | b | |" in result
 
 
 def test_list_processing():

--- a/trafilatura/main_extractor.py
+++ b/trafilatura/main_extractor.py
@@ -409,6 +409,9 @@ def handle_table(table_elem, potential_tags, options):
         # cleanup
         subelement.tag = "done"
 
+    # clean up row attributes
+    newrow.attrib.pop("span", None)
+
     # end of processing
     if len(newrow) > 0:
         newtable.append(newrow)

--- a/trafilatura/main_extractor.py
+++ b/trafilatura/main_extractor.py
@@ -357,16 +357,19 @@ def handle_table(table_elem, potential_tags, options):
         max_cols = max(max_cols, sum(int(td.get("colspan", 1)) for td in tr.iter(TABLE_ELEMS)))
 
     # explore sub-elements
+    seen_header_row = False
     seen_header = False
-    newrow = Element("row", span=str(max_cols))
+    row_attrs = {"span": str(max_cols)} if max_cols > 1 else {}
+    newrow = Element("row", **row_attrs)
     for subelement in table_elem.iterdescendants():
         if subelement.tag == "tr":
             # process existing row
             if len(newrow) > 0:
                 newtable.append(newrow)
-                newrow = Element("row", span=str(max_cols))
+                newrow = Element("row", **row_attrs)
+                seen_header_row = seen_header_row or seen_header
         elif subelement.tag in TABLE_ELEMS:
-            is_header = subelement.tag == "th" and not seen_header
+            is_header = subelement.tag == "th" and not seen_header_row
             seen_header = seen_header or is_header
             new_child_elem = define_cell_type(subelement, is_header)
             # process

--- a/trafilatura/main_extractor.py
+++ b/trafilatura/main_extractor.py
@@ -335,11 +335,11 @@ def handle_paragraphs(element, potential_tags, options):
     return None
 
 
-def define_cell_type(element):
+def define_cell_type(element, is_header):
     "Determine cell element type and mint new element."
     # define tag
     cell_element = Element("cell")
-    if element.tag == "th":
+    if is_header:
         cell_element.set("role", "head")
     return cell_element
 
@@ -353,6 +353,7 @@ def handle_table(table_elem, potential_tags, options):
     strip_tags(table_elem, "thead", "tbody", "tfoot")
 
     # explore sub-elements
+    seen_header = False
     for subelement in table_elem.iterdescendants():
         if subelement.tag == "tr":
             # process existing row
@@ -360,7 +361,9 @@ def handle_table(table_elem, potential_tags, options):
                 newtable.append(newrow)
                 newrow = Element("row")
         elif subelement.tag in TABLE_ELEMS:
-            new_child_elem = define_cell_type(subelement)
+            is_header = subelement.tag == "th" and not seen_header
+            seen_header = seen_header or is_header
+            new_child_elem = define_cell_type(subelement, is_header)
             # process
             if len(subelement) == 0:
                 processed_cell = process_node(subelement, options)

--- a/trafilatura/main_extractor.py
+++ b/trafilatura/main_extractor.py
@@ -347,19 +347,24 @@ def define_cell_type(element, is_header):
 def handle_table(table_elem, potential_tags, options):
     "Process single table element."
     newtable = Element("table")
-    newrow = Element("row")
 
     # strip these structural elements
     strip_tags(table_elem, "thead", "tbody", "tfoot")
 
+    # calculate maximum number of columns per row, includin colspan
+    max_cols = 0
+    for tr in table_elem.iter('tr'):
+        max_cols = max(max_cols, sum(int(td.get("colspan", 1)) for td in tr.iter(TABLE_ELEMS)))
+
     # explore sub-elements
     seen_header = False
+    newrow = Element("row", span=str(max_cols))
     for subelement in table_elem.iterdescendants():
         if subelement.tag == "tr":
             # process existing row
             if len(newrow) > 0:
                 newtable.append(newrow)
-                newrow = Element("row")
+                newrow = Element("row", span=str(max_cols))
         elif subelement.tag in TABLE_ELEMS:
             is_header = subelement.tag == "th" and not seen_header
             seen_header = seen_header or is_header

--- a/trafilatura/xml.py
+++ b/trafilatura/xml.py
@@ -297,7 +297,7 @@ def process_element(element, returnlist, include_formatting):
         if element.tag in NEWLINE_ELEMS:
             # add line after table head
             if element.tag == "row":
-                max_span = int(element.get("span", 0))
+                max_span = int(element.get("span", 1))
                 cell_count = len(element.xpath(".//cell"))
                 # row ended so draw extra empty cells to match max_span
                 returnlist.append("|" * (max_span - cell_count) + "\n")

--- a/trafilatura/xml.py
+++ b/trafilatura/xml.py
@@ -302,10 +302,13 @@ def process_element(element, returnlist, include_formatting):
     # Process text
 
     # Common elements (Now processes end-tag logic correctly)
+    within_cell = element.xpath("ancestor::cell")
     if element.tag == 'p' and include_formatting:
-        returnlist.append('\n\u2424\n')
+        if not within_cell:
+            returnlist.append('\n\u2424\n')
     elif element.tag in NEWLINE_ELEMS:
-        returnlist.extend([NEWLINE_ELEMS[element.tag], '\n'])
+        if not within_cell:
+            returnlist.extend([NEWLINE_ELEMS[element.tag], '\n'])
     elif element.tag == 'cell':
         returnlist.extend(" | ")
     elif element.tag == 'comments':

--- a/trafilatura/xml.py
+++ b/trafilatura/xml.py
@@ -217,6 +217,7 @@ def replace_element_text(element, include_formatting):
     "Determine element text based on just the text of the element. One must deal with the tail separately."
     elem_text = element.text or ""
     # handle formatting: convert to markdown
+    children = element.getchildren()
     if include_formatting and element.text:
         if element.tag == "head":
             try:
@@ -247,6 +248,9 @@ def replace_element_text(element, include_formatting):
                 elem_text = link_text
         else:
             LOGGER.warning("empty link: %s %s", elem_text, element.attrib)
+    # cells
+    if element.tag == "cell" and elem_text and children and children[0].tag == 'p':
+        elem_text = f"{elem_text} "
     # lists
     elif element.tag == "item" and elem_text:
         elem_text = f"- {elem_text}\n"

--- a/trafilatura/xml.py
+++ b/trafilatura/xml.py
@@ -31,7 +31,7 @@ PKG_VERSION = version("trafilatura")
 TEI_SCHEMA = str(Path(__file__).parent / 'data/tei-schema-pickle.lzma')
 TEI_VALID_TAGS = {'ab', 'body', 'cell', 'code', 'del', 'div', 'graphic', 'head', 'hi', \
                   'item', 'lb', 'list', 'p', 'quote', 'ref', 'row', 'table'}
-TEI_VALID_ATTRS = {'rend', 'rendition', 'role', 'target', 'type', 'foo'}
+TEI_VALID_ATTRS = {'rend', 'rendition', 'role', 'target', 'type'}
 TEI_RELAXNG = None  # to be downloaded later if necessary
 TEI_REMOVE_TAIL = {"ab", "p"}
 TEI_DIV_SIBLINGS = {"p", "list", "table", "quote", "ab"}
@@ -307,7 +307,10 @@ def process_element(element, returnlist, include_formatting):
                     returnlist.append("\n" + "---|" * max_span + "\n")
             else:
                 returnlist.append('\n')
-        return  # Nothing more to do with textless elements
+        if element.tag != 'cell':
+            # cells still need to append vertical bars
+            # but nothing more to do with other textless elements
+            return
 
     # Process text
 


### PR DESCRIPTION
Contains the following fixes:
- do not add new lines in markdown cells
- markdown tables can only have one header
- add a space after text before a paragraph in a cell
- match maximum cell count on each row
- cells always need to append vertical bars

Partly fixes https://github.com/adbar/trafilatura/issues/599.