### PR TITLE
output formats: enforce fixed list, deprecate -out on the CLI

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -45,8 +45,12 @@ To tailor the output to your specific requirements, Trafilatura allows you to co
     # change the output format to XML (allowing for preservation of document structure)
     >>> result = extract(downloaded, output_format="xml")
 
-    # discard potential comment and change the output to JSON
+    # discard potential comments, extract metadata and change the output to JSON
     >>> extract(downloaded, output_format="json", include_comments=False)
+
+    # set the output to Markdown and extract metadata
+    >>> extract(downloaded, output_format="markdown", with_metadata=True)
+
 
 
 Fast mode

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 # with version specifier
 sphinx>=7.3.7
-pydata-sphinx-theme>=0.15.3
+pydata-sphinx-theme>=0.15.4
 docutils>=0.21.2
 # without version specifier
 trafilatura

--- a/docs/usage-cli.rst
+++ b/docs/usage-cli.rst
@@ -60,24 +60,22 @@ Choice of HTML elements
 
 Several elements can be included or discarded (see list of options below):
 
-* Text elements: comments, tables
-* Structural elements: formatting, images, links
+- Text elements
+   - Comments and tables are extracted by default.
+   - ``--no-comments`` and ``--no-tables`` deactivate these settings.
 
-Only comments and text extracted from HTML ``<table>`` elements are extracted by default, ``--no-comments`` and ``--no-tables`` deactivate this setting.
-
-Further options:
-
-``--formatting``
-    Keep structural elements related to formatting (``<b>``/``<strong>``, ``<i>``/``<emph>`` etc.)
-``--links``
-    Keep link targets (in ``href="..."``), converting relative URLs to absolute where possible
-``--images``
-    Keep track of images along with their targets (``<img>`` attributes: alt, src, title)
+- Structural elements
+   ``--formatting``
+      Keep structural elements related to formatting (``<b>``/``<strong>``, ``<i>``/``<emph>`` etc.)
+   ``--links``
+      Keep link targets (in ``href="..."``), converting relative URLs to absolute where possible
+   ``--images``
+      Keep track of images along with their targets (``<img>`` attributes: alt, src, title)
 
 .. note::
     Certain elements are only visible in the output if the chosen format allows it (e.g. images and XML). Including extra elements works best with conversion to XML/XML-TEI.
 
-    The heuristics used by the main algorithm change according to the presence of certain elements in the HTML. If the output seems odd removing a constraint (e.g. formatting) can greatly improve the result.
+    The heuristics used by the main algorithm change according to the presence of certain elements in the HTML. If the output seems odd, try removing a constraint (e.g. formatting) to improve the result.
 
 
 Output format
@@ -85,28 +83,29 @@ Output format
 
 Output as TXT without metadata is the default, another format can be selected in two different ways:
 
--  ``--csv``, ``--json``, ``--markdown`` (from version 1.9 onwards), ``--xml`` or ``--xmltei``
--  ``-out`` or ``--output-format`` {txt,csv,json,markdown,xml,xmltei}
+-  ``--csv``, ``--html``, ``--json``, ``--markdown``, ``--xml`` or ``--xmltei``
+-  ``--output-format`` {csv,json,html,markdown,txt,xml,xmltei}
 
 .. hint::
-    Combining TXT, CSV and JSON formats with certain structural elements (e.g. formatting or links) triggers output in TXT+Markdown format. Selecting markdown automatically includes text formatting.
+    Combining TXT, CSV and JSON formats with certain structural elements (e.g. formatting or links) triggers output in Markdown format. Selecting Markdown automatically includes text formatting.
+
+*HTML output is available from version 1.11, Markdown from version 1.9 onwards.*
 
 
 Optimizing for precision and recall
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The arguments ``--precision`` & ``--recall`` can be passed to the extractor. They affect processing and volume of textual output:
+The arguments ``--precision`` or ``--recall`` can be passed to adjust the focus of the extraction process.
 
-1. By focusing precision/accuracy, i.e. more selective extraction, yielding less and more central elements.
-   If you believe the results are too noisy, try focusing on precision.
-2. By enhancing recall, i.e. more opportunistic extraction, taking more elements into account.
-   If parts of the contents are still missing, see `troubleshooting <troubleshooting.html>`_.
+- If your results contain too much noise, prioritize precision to focus on the most central and relevant elements.
+- If parts of your documents are missing, try this preset to take more elements into account.
+- If parts of the contents are still missing, see `troubleshooting <troubleshooting.html>`_.
 
 
 Language identification
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Passing the argument ``--target-language`` along with a 2-letter code (`ISO 639-1 <https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes>`_) will trigger language filtering of the output if the identification component has been `installed <installation.html>`_ and if the target language is available.
+Passing the argument ``--target-language`` along with a 2-letter code (ISO 639-1) will trigger language filtering of the output if the identification component has been `installed <installation.html>`_ and if the target language is available.
 
 .. note::
     Additional components are required: ``pip install trafilatura[all]``.
@@ -283,8 +282,8 @@ For all usage instructions see ``trafilatura -h``:
                    [--no-tables] [--only-with-metadata]
                    [--target-language TARGET_LANGUAGE] [--deduplicate]
                    [--config-file CONFIG_FILE] [--precision] [--recall]
-                   [-out {txt,csv,html,json,markdown,xml,xmltei} | --csv | --html |
-                   --json | --markdown | --xml | --xmltei]
+                   [--output-format {csv,json,html,markdown,txt,xml,xmltei} | 
+                   --csv | --html | --json | --markdown | --xml | --xmltei]
                    [--validate-tei] [-v] [--version]
 
 
@@ -360,7 +359,8 @@ Format:
 
 .. code-block:: bash
 
-  -out {txt,csv,html,json,markdown,xml,xmltei}, --output-format {txt,csv,html,json,markdown,xml,xmltei}
+  --output-format {csv,json,html,markdown,txt,xml,xmltei}
+                        determine output format
   --csv                 shorthand for CSV output
   --html                shorthand for HTML output
   --json                shorthand for JSON output

--- a/tests/cli_tests.py
+++ b/tests/cli_tests.py
@@ -39,7 +39,7 @@ def test_parser():
     assert args.URL == "https://www.example.org"
     args = cli.map_args(args)
     assert args.output_format == "xmltei"
-    testargs = ["", "-out", "csv", "--no-tables", "-u", "https://www.example.org"]
+    testargs = ["", "--output-format", "csv", "--no-tables", "-u", "https://www.example.org"]
     with patch.object(sys, "argv", testargs):
         args = cli.parse_args(testargs)
     assert args.fast is False
@@ -129,6 +129,9 @@ def test_parser():
     with patch.object(sys, "argv", testargs), pytest.raises(ValueError):
         cli.map_args(cli.parse_args(testargs))
     testargs = ["", "--outputdir", "test2"]
+    with patch.object(sys, "argv", testargs), pytest.raises(ValueError):
+        cli.map_args(cli.parse_args(testargs))
+    testargs = ["", "-out", "xml"]
     with patch.object(sys, "argv", testargs), pytest.raises(ValueError):
         cli.map_args(cli.parse_args(testargs))
 
@@ -329,7 +332,7 @@ def test_cli_pipeline():
         args = cli.parse_args(testargs)
     cli_utils.archive_html("00Test", args)
     # test date-based exclusion
-    testargs = ["", "-out", "xml", "--only-with-metadata"]
+    testargs = ["", "--output-format", "xml", "--only-with-metadata"]
     with patch.object(sys, "argv", testargs):
         args = cli.parse_args(testargs)
     with open(
@@ -337,7 +340,7 @@ def test_cli_pipeline():
     ) as f:
         teststring = f.read()
     assert cli.examine(teststring, args) is None
-    testargs = ["", "-out", "xml", "--only-with-metadata", "--precision"]
+    testargs = ["", "--output-format", "xml", "--only-with-metadata", "--precision"]
     with patch.object(sys, "argv", testargs):
         args = cli.parse_args(testargs)
     with open(
@@ -346,7 +349,7 @@ def test_cli_pipeline():
         teststring = f.read()
     assert cli.examine(teststring, args) is None
     # test JSON output
-    testargs = ["", "-out", "json", "--recall"]
+    testargs = ["", "--output-format", "json", "--recall"]
     with patch.object(sys, "argv", testargs):
         args = cli.parse_args(testargs)
     with open(

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -73,11 +73,12 @@ def load_mock_page(url, xml_flag=False, langcheck=None, tei_output=False):
                 htmlstring = htmlbinary
         else:
             print('Encoding error')
-    output_format = 'txt'
-    if xml_flag is True:
+    if xml_flag:
         output_format = 'xml'
-    if tei_output is True:
-        output_format = 'tei'
+    elif tei_output:
+        output_format = 'xmltei'
+    else:
+        output_format = 'txt'
     return extract(htmlstring, url,
                      record_id='0000',
                      no_fallback=False,

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -164,8 +164,11 @@ def test_input():
 
     # output format
     assert extract('<html><body><p>ABC</p></body></html>', output_format="xml") is not None
-    with pytest.raises(ValueError):
+    with pytest.raises(AttributeError):
         assert extract('<html><body><p>ABC</p></body></html>', output_format="xyz") is not None
+    assert bare_extraction('<html><body><p>ABC</p></body></html>', output_format="python") is not None
+    with pytest.raises(AttributeError):
+        assert bare_extraction('<html><body><p>ABC</p></body></html>', output_format="xyz") is not None
 
 
 def test_xmltocsv():
@@ -782,8 +785,10 @@ def test_htmlprocessing():
 def test_extraction_options():
     '''Test the different parameters available in extract() and bare_extraction()'''
     my_html = '<html><head><meta http-equiv="content-language" content="EN"/></head><body><div="article-body"><p>Text.<!-- comment --></p></div></body></html>'
-    with pytest.raises(NameError) as err:
+    with pytest.raises(ValueError) as err:
         extract(my_html, json_output=True)
+    with pytest.raises(ValueError) as err:
+        extract(my_html, output_format="python")
     assert extract(my_html, config=NEW_CONFIG) is None
     assert extract(my_html, config=ZERO_CONFIG) is not None
     assert extract(my_html, only_with_metadata=False, output_format='xml', config=ZERO_CONFIG) is not None

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -141,6 +141,7 @@ def test_input():
     with pytest.raises(TypeError) as err:
         assert load_html(123) is None
     assert 'incompatible' in str(err.value)
+
     assert load_html('<html><body>ÄÖÜ</body></html>') is not None
     assert load_html(b'<html><body>\x2f\x2e\x9f</body></html>') is not None
     assert load_html('<html><body>\x2f\x2e\x9f</body></html>'.encode('latin-1')) is not None
@@ -159,6 +160,11 @@ def test_input():
     assert normalize_unicode('A\u0308ffin') != 'A\u0308ffin'
     testresult = extract('<html><body><p>A\u0308ffin</p></body></html>', config=ZERO_CONFIG)
     assert testresult != 'A\u0308ffin' and testresult == 'Äffin'
+
+    # output format
+    assert extract('<html><body><p>ABC</p></body></html>', output_format="xml") is not None
+    with pytest.raises(ValueError):
+        assert extract('<html><body><p>ABC</p></body></html>', output_format="xyz") is not None
 
 
 def test_xmltocsv():

--- a/trafilatura/cli.py
+++ b/trafilatura/cli.py
@@ -17,7 +17,7 @@ from .cli_utils import (cli_crawler, cli_discovery, examine,
                         file_processing_pipeline, load_blacklist,
                         load_input_dict, probe_homepage,
                         url_processing_pipeline, write_result)
-from .settings import PARALLEL_CORES
+from .settings import PARALLEL_CORES, SUPPORTED_FORMATS
 
 # fix output encoding on some systems
 try:
@@ -160,9 +160,12 @@ def add_args(parser):
                         action="store_true")
 
     # https://docs.python.org/3/library/argparse.html#argparse.ArgumentParser.add_mutually_exclusive_group
-    group5_ex.add_argument('-out', '--output-format',
+    group5_ex.add_argument("-out",
+                        help=argparse.SUPPRESS,
+                        choices=sorted(SUPPORTED_FORMATS))
+    group5_ex.add_argument('--output-format',
                         help="determine output format",
-                        choices=['txt', 'csv', 'html', 'json', 'markdown', 'xml', 'xmltei'],
+                        choices=sorted(SUPPORTED_FORMATS),
                         default='txt')
     group5_ex.add_argument("--csv",
                         help="shorthand for CSV output",
@@ -238,6 +241,10 @@ def map_args(args):
     if args.hash_as_name:
         raise ValueError(
               "--hash-as-name is deprecated, hashes are used by default",
+              )
+    if args.out:
+        raise ValueError(
+              "-out is deprecated, use --output-format instead",
               )
     return args
 

--- a/trafilatura/cli.py
+++ b/trafilatura/cli.py
@@ -17,7 +17,7 @@ from .cli_utils import (cli_crawler, cli_discovery, examine,
                         file_processing_pipeline, load_blacklist,
                         load_input_dict, probe_homepage,
                         url_processing_pipeline, write_result)
-from .settings import PARALLEL_CORES, SUPPORTED_FORMATS
+from .settings import PARALLEL_CORES, SUPPORTED_FMT_CLI
 
 # fix output encoding on some systems
 try:
@@ -162,10 +162,10 @@ def add_args(parser):
     # https://docs.python.org/3/library/argparse.html#argparse.ArgumentParser.add_mutually_exclusive_group
     group5_ex.add_argument("-out",
                         help=argparse.SUPPRESS,
-                        choices=sorted(SUPPORTED_FORMATS))
+                        choices=sorted(SUPPORTED_FMT_CLI))
     group5_ex.add_argument('--output-format',
                         help="determine output format",
-                        choices=sorted(SUPPORTED_FORMATS),
+                        choices=sorted(SUPPORTED_FMT_CLI),
                         default='txt')
     group5_ex.add_argument("--csv",
                         help="shorthand for CSV output",

--- a/trafilatura/cli.py
+++ b/trafilatura/cli.py
@@ -162,10 +162,10 @@ def add_args(parser):
     # https://docs.python.org/3/library/argparse.html#argparse.ArgumentParser.add_mutually_exclusive_group
     group5_ex.add_argument("-out",
                         help=argparse.SUPPRESS,
-                        choices=sorted(SUPPORTED_FMT_CLI))
+                        choices=SUPPORTED_FMT_CLI)
     group5_ex.add_argument('--output-format',
                         help="determine output format",
-                        choices=sorted(SUPPORTED_FMT_CLI),
+                        choices=SUPPORTED_FMT_CLI,
                         default='txt')
     group5_ex.add_argument("--csv",
                         help="shorthand for CSV output",

--- a/trafilatura/core.py
+++ b/trafilatura/core.py
@@ -25,6 +25,8 @@ from .xpaths import REMOVE_COMMENTS_XPATH
 
 LOGGER = logging.getLogger(__name__)
 
+TXT_FORMATS = {"markdown", "txt"}
+
 
 def determine_returnstring(document, options):
     '''Convert XML tree to chosen format, clean the result and output it as a string'''
@@ -347,7 +349,7 @@ def extract(filecontent, url=None, record_id=None, no_fallback=False,
     if document is None:
         return None
 
-    if options.format not in ("markdown", "txt"):
+    if options.format not in TXT_FORMATS:
         # add record ID to metadata
         document.id = record_id
         # calculate fingerprint

--- a/trafilatura/core.py
+++ b/trafilatura/core.py
@@ -25,6 +25,7 @@ from .xpaths import REMOVE_COMMENTS_XPATH
 
 LOGGER = logging.getLogger(__name__)
 
+DEPRECATED_ARGS = ('csv_output', 'json_output', 'tei_output', 'xml_output')
 TXT_FORMATS = {"markdown", "txt"}
 
 
@@ -306,16 +307,10 @@ def extract(filecontent, url=None, record_id=None, no_fallback=False,
         A string in the desired format or None.
 
     """
-    # older, deprecated functions
-    if kwargs and any([
-        # output formats
-            'csv_output' in kwargs,
-            'json_output' in kwargs,
-            'tei_output' in kwargs,
-            'xml_output' in kwargs
-        ]):
-        raise NameError(
-            'Deprecated argument: use output_format instead, e.g. output_format="xml"'
+    # older, deprecated functions still found in tutorials
+    if kwargs and any(arg in kwargs for arg in DEPRECATED_ARGS):
+        raise ValueError(
+            'Deprecated argument: use output_format, e.g. output_format="xml"'
             )
 
     # regroup extraction options
@@ -332,9 +327,6 @@ def extract(filecontent, url=None, record_id=None, no_fallback=False,
                       date_params=date_extraction_params
                   )
 
-    # markdown switch
-    include_formatting = include_formatting or output_format == "markdown"
-
     # extraction
     try:
         document = bare_extraction(
@@ -350,6 +342,9 @@ def extract(filecontent, url=None, record_id=None, no_fallback=False,
         return None
 
     if options.format not in TXT_FORMATS:
+        # control output
+        if options.format == "python":
+            raise ValueError("'python' format only usable in bare_extraction() function")
         # add record ID to metadata
         document.id = record_id
         # calculate fingerprint

--- a/trafilatura/settings.py
+++ b/trafilatura/settings.py
@@ -22,6 +22,16 @@ from lxml.etree import XPath
 from .utils import line_processing
 
 
+SUPPORTED_FORMATS = {"csv", "json", "html", "markdown", "txt", "xml", "xmltei"}
+_SUPPORTED = ', '.join(sorted(SUPPORTED_FORMATS))
+
+
+def _check_output_format(chosen_format: str) -> None:
+    "Check if the format is supported and raise an error otherwise."
+    if chosen_format not in SUPPORTED_FORMATS:
+        raise ValueError(f"Invalid output format, allowed values are: {_SUPPORTED}")
+
+
 def use_config(filename=None, config=None):
     """
     Use configuration object or read and parse a settings file.
@@ -79,6 +89,7 @@ class Extractor:
                  tables=True, dedup=False, lang=None, max_tree_size=None,
                  url=None, source=None, with_metadata=False, only_with_metadata=False, tei_validation=False,
                  author_blacklist=None, url_blacklist=None, date_params=None):
+        _check_output_format(output_format)
         self._add_config(config)
         self.format = output_format
         self.fast = fast

--- a/trafilatura/settings.py
+++ b/trafilatura/settings.py
@@ -23,14 +23,7 @@ from .utils import line_processing
 
 
 SUPPORTED_FMT_CLI = ["csv", "json", "html", "markdown", "txt", "xml", "xmltei"]
-SUPPORTED_FORMATS = set(SUPPORTED_FMT_CLI) | {"python"}  # the latter for bare_extraction() only
-_SUPPORTED = ', '.join(sorted(SUPPORTED_FORMATS))
-
-
-def _check_output_format(chosen_format: str) -> None:
-    "Check if the format is supported and raise an error otherwise."
-    if chosen_format not in SUPPORTED_FORMATS:
-        raise ValueError(f"Invalid output format, allowed values are: {_SUPPORTED}")
+SUPPORTED_FORMATS = set(SUPPORTED_FMT_CLI) | {"python"}  # for bare_extraction() only
 
 
 def use_config(filename=None, config=None):
@@ -90,9 +83,8 @@ class Extractor:
                  tables=True, dedup=False, lang=None, max_tree_size=None,
                  url=None, source=None, with_metadata=False, only_with_metadata=False, tei_validation=False,
                  author_blacklist=None, url_blacklist=None, date_params=None):
-        _check_output_format(output_format)
+        self._set_format(output_format)
         self._add_config(config)
-        self.format = output_format
         self.fast = fast
         self.focus = "recall" if recall else "precision" if precision else "balanced"
         self.comments = comments
@@ -113,6 +105,12 @@ class Extractor:
                               url_blacklist or output_format == "xmltei")
         self.date_params = (date_params or
                             set_date_params(self.config.getboolean('DEFAULT', 'EXTENSIVE_DATE_SEARCH')))
+
+    def _set_format(self, chosen_format: str) -> None:
+        "Store the format if supported and raise an error otherwise."
+        if chosen_format not in SUPPORTED_FORMATS:
+            raise AttributeError(f"Cannot set format, must be one of: {', '.join(sorted(SUPPORTED_FORMATS))}")
+        self.format = chosen_format
 
     def _add_config(self, config):
         "Store options loaded from config file."

--- a/trafilatura/settings.py
+++ b/trafilatura/settings.py
@@ -22,7 +22,8 @@ from lxml.etree import XPath
 from .utils import line_processing
 
 
-SUPPORTED_FORMATS = {"csv", "json", "html", "markdown", "txt", "xml", "xmltei"}
+SUPPORTED_FMT_CLI = ["csv", "json", "html", "markdown", "txt", "xml", "xmltei"]
+SUPPORTED_FORMATS = set(SUPPORTED_FMT_CLI) | {"python"}  # the latter for bare_extraction() only
 _SUPPORTED = ', '.join(sorted(SUPPORTED_FORMATS))
 
 


### PR DESCRIPTION
- [x] define list of supported format and enforce it before running the extraction
- [x] deprecate useless `-out` option on the CLI in favor of `--output-format`
- [x] add `"python"` to the list of accepted formats for `bare_extraction()` only (and add tests)
- [x] update docs