### PR TITLE
Fixed incorrect variable passed to extract_metadata

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -87,7 +87,7 @@ The tool can also extract specific information from a web page, such as the titl
 
     >>> from trafilatura import fetch_url, extract_metadata
     >>> downloaded = fetch_url('https://github.blog/2019-03-29-leader-spotlight-erin-spiceland/')
-    >>> extract_metadata(url)
+    >>> extract_metadata(downloaded)
 
 
 On the command-line


### PR DESCRIPTION
An incorrect variable (url) was previously passed to the `filecontent` parameter of the **extract_metadata** function, which expects HTML code as a string.

This problem was solved by passing the result of the **fetch_url** function (stored in the variable `downloaded`) to **extract_metadata**::

```python
from trafilatura import fetch_url, extract_metadata

downloaded = fetch_url('https://github.blog/2019-03-29-leader-spotlight-erin-spiceland/')
extract_metadata(downloaded)
```