### PR TITLE
maintenance: make compression libraries optional

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -88,6 +88,12 @@ For local or user installations where trafilatura cannot be used from the comman
 Additional functionality
 ------------------------
 
+Compression
+~~~~~~~~~~~
+
+Trafilatura works best if compression modules in the Python standard library are available. If this is not the case the following modules are impacted: processing of compressed HTML data (less coverage), backup HTML storage (CLI), and UrlStore in the underlying courlan library (lesser capacity).
+
+
 Optional modules
 ~~~~~~~~~~~~~~~~
 

--- a/trafilatura/cli_utils.py
+++ b/trafilatura/cli_utils.py
@@ -2,7 +2,12 @@
 Functions dedicated to command-line processing.
 """
 
-import gzip
+try:
+    import gzip
+    HAS_GZIP = True
+except ImportError:
+    HAS_GZIP = False
+
 import logging
 import random
 import re
@@ -179,7 +184,7 @@ def archive_html(htmlstring: str, args: Any, counter: int = -1) -> str:
     destination_directory = determine_counter_dir(args.backup_dir, counter)
     output_path, filename = get_writable_path(destination_directory, ".html.gz")
     # check the directory status
-    if check_outputdir_status(destination_directory) is True:
+    if check_outputdir_status(destination_directory) is True and HAS_GZIP:
         # write
         with gzip.open(output_path, "wb") as outputfile:
             outputfile.write(htmlstring.encode("utf-8"))

--- a/trafilatura/utils.py
+++ b/trafilatura/utils.py
@@ -4,10 +4,20 @@ Module bundling functions related to HTML and text processing,
 content filtering and language detection.
 """
 
-import gzip
+try:
+    import gzip
+    HAS_GZIP = True
+except ImportError:
+    HAS_GZIP = False
+
 import logging
 import re
-import zlib
+
+try:
+    import zlib
+    HAS_ZLIB = True
+except ImportError:
+    HAS_ZLIB = False
 
 from functools import lru_cache
 from itertools import islice
@@ -90,7 +100,7 @@ def handle_compressed_file(filecontent):
         return filecontent
 
     # source: https://stackoverflow.com/questions/3703276/how-to-tell-if-a-file-is-gzip-compressed
-    if filecontent[:3] == b"\x1f\x8b\x08":
+    if HAS_GZIP and filecontent[:3] == b"\x1f\x8b\x08":
         try:
             return gzip.decompress(filecontent)
         except Exception:  # EOFError, OSError, gzip.BadGzipFile
@@ -108,10 +118,11 @@ def handle_compressed_file(filecontent):
         except brotli.error:
             pass  # logging.debug('invalid Brotli file')
     # try zlib/deflate
-    try:
-        return zlib.decompress(filecontent)
-    except zlib.error:
-        pass
+    if HAS_ZLIB:
+        try:
+            return zlib.decompress(filecontent)
+        except zlib.error:
+            pass
 
     # return content unchanged if decompression failed
     return filecontent


### PR DESCRIPTION
Compression libraries in the standard Python library are not always available on all systems, see also #559.