### PR TITLE
fix: set options.source before raising error on empty doc tree

### DIFF
--- a/trafilatura/core.py
+++ b/trafilatura/core.py
@@ -147,11 +147,6 @@ def bare_extraction(filecontent, url=None, no_fallback=False,  # fast=False,
 
     # load data
     try:
-        tree = load_html(filecontent)
-        if tree is None:
-            LOGGER.error('empty HTML tree: %s', url)
-            raise ValueError
-
         # regroup extraction options
         if not options or not isinstance(options, Extractor):
             options = Extractor(
@@ -164,6 +159,12 @@ def bare_extraction(filecontent, url=None, no_fallback=False,  # fast=False,
                           author_blacklist=author_blacklist, url_blacklist=url_blacklist,
                           date_params=date_extraction_params
                       )
+        
+        # load the HTML tree
+        tree = load_html(filecontent)
+        if tree is None:
+            LOGGER.error('empty HTML tree: %s', url)
+            raise ValueError
 
         # quick and dirty HTML lang check
         if options.lang and (options.fast or not LANGID_FLAG):


### PR DESCRIPTION
Made sure the `options` variable is properly backfilled before any exception can be raised

This fixes #705