### PR TITLE
Use rst link instead of markdown link in `docs/index.html`

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -63,7 +63,7 @@ Features
    - TXT and Markdown
    - CSV
    - JSON
-   - HTML, XML and [XML-TEI](https://tei-c.org/)
+   - HTML, XML and `XML-TEI <https://tei-c.org/>`_
 - Optional add-ons:
    - Language detection on extracted content
    - Graphical user interface (GUI)


### PR DESCRIPTION
I found that one link uses a markdown style but it should be rst.