### PR TITLE
cli: also stream URL list gathered from feeds

### DIFF
--- a/trafilatura/cli_utils.py
+++ b/trafilatura/cli_utils.py
@@ -312,7 +312,7 @@ def cli_discovery(args: Any) -> None:
                 url_store.add_urls(future.result())
                 # empty buffer in order to spare memory
                 if (
-                    args.sitemap
+                    (args.sitemap or args.feed)
                     and args.list
                     and len(url_store.get_known_domains()) >= args.parallel
                 ):


### PR DESCRIPTION
The use case of listing URLs from feeds seems analogeous to that of listing URLs from sitemaps. Accordingly, gathered URLs could be streamed to standard output instead of being collected until all feeds have been retrieved.