### PR TITLE
refine table markdown output

### DIFF
--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -1022,7 +1022,7 @@ def test_table_processing():
         <cell>you buy</cell>
         <cell>they buy</cell>
       </row>''' in my_result
-    assert extract(htmlstring, fast=True, output_format='txt').startswith("Present Tense | I buy | you buy |")
+    assert extract(htmlstring, fast=True, output_format='txt').startswith("| Present Tense | I buy | you buy |")
     # table with links
     # todo: further tests and adjustments
     htmlstring = '<html><body><article><table><tr><td><a href="test.html">' + 'ABCD'*100 + '</a></td></tr></table></article></body></html>'
@@ -1112,12 +1112,12 @@ def test_table_processing():
     assert "1" in result and "2" in result
     # table headers in non-XML formats
     htmlstring = '<html><body><article><table><tr><th>head 1</th><th>head 2</th></tr><tr><td>1</td><td>2</td></tr></table></article></body></html>'
-    assert "---|---|" in extract(htmlstring, fast=True, output_format='txt', config=ZERO_CONFIG, include_tables=True)
+    assert "|---|---|" in extract(htmlstring, fast=True, output_format='txt', config=ZERO_CONFIG, include_tables=True)
 
     # remove new lines in table cells in text format
     htmlstring = '<html><body><article><table><tr><td>cell<br>1</td><td>cell<p>2</p></td></tr></table></article></body></html>'
     result = extract(htmlstring, fast=True, output_format='txt', config=ZERO_CONFIG, include_tables=True)
-    assert "cell 1 | cell 2 |" in result
+    assert "| cell 1 | cell 2 |" in result
 
     # only one header row is allowed in text format
     htmlstring = '<html><body><article><table><tr><th>a</th><th>b</th></tr><tr><th>c</th><th>d</th></tr></table></article></body></html>'
@@ -1127,15 +1127,15 @@ def test_table_processing():
     # handle colspan by appending columns in text format
     htmlstring = '<html><body><article><table><tr><td colspan="2">a</td><td>b</td></tr><tr><td>c</td><td>d</td><td>e</td></tr></table></article></body></html>'
     result = extract(htmlstring, fast=True, output_format='txt', config=ZERO_CONFIG, include_tables=True)
-    assert "a | b | |" in result
+    assert "| a | b | |" in result
 
     htmlstring = '<html><body><article><table><tr><td span="2">a</td><td>b</td></tr><tr><td>c</td><td>d</td><td>e</td></tr></table></article></body></html>'
     result = extract(htmlstring, fast=True, output_format='txt', config=ZERO_CONFIG, include_tables=True)
-    assert "a | b | |" in result
+    assert "| a | b | |" in result
 
     htmlstring = '<html><body><article><table><tr><td span="2.1">a</td><td>b</td></tr><tr><td>c</td><td>d</td><td>e</td></tr></table></article></body></html>'
     result = extract(htmlstring, fast=True, output_format='txt', config=ZERO_CONFIG, include_tables=True)
-    assert "a | b | |" in result
+    assert "| a | b | |" in result
 
     # MemoryError: https://github.com/adbar/trafilatura/issues/657
     htmlstring = '<html><body><article><table><tr><td colspan="9007199254740991">a</td><td>b</td></tr><tr><td>c</td><td>d</td><td>e</td></tr></table></article></body></html>'
@@ -1149,16 +1149,16 @@ def test_table_processing():
     # wrong span info
     htmlstring = '<html><body><article><table><tr><td span="-1">a</td><td>b</td></tr><tr><td>c</td><td>d</td><td>e</td></tr></table></article></body></html>'
     result = extract(htmlstring, fast=True, output_format='txt', config=ZERO_CONFIG, include_tables=True)
-    assert "a | b | |" in result
+    assert "| a | b | |" in result
 
     htmlstring = '<html><body><article><table><tr><td span="abc">a</td><td>b</td></tr><tr><td>c</td><td>d</td><td>e</td></tr></table></article></body></html>'
     result = extract(htmlstring, fast=True, output_format='txt', config=ZERO_CONFIG, include_tables=True)
-    assert "a | b | |" in result
+    assert "| a | b | |" in result
 
     # links: this gets through (for now)
     htmlstring = '<html><body><article><table><tr><td><a href="link.html">a</a></td></tr></table></article></body></html>'
     result = extract(htmlstring, fast=True, output_format='txt', config=ZERO_CONFIG, include_tables=True)
-    assert result == "a |"
+    assert result == "| a |"
 
     # link: this is filtered out
     htmlstring = f'<html><body><article><table><tr><td><a href="link.html">{"abc"*100}</a></td></tr></table></article></body></html>'

--- a/trafilatura/xml.py
+++ b/trafilatura/xml.py
@@ -288,6 +288,9 @@ def replace_element_text(element: _Element, include_formatting: bool) -> str:
     if element.tag == "cell" and elem_text and len(element) > 0:
         if element[0].tag == 'p':
             elem_text = f"{elem_text} "
+    elif element.tag == 'cell' and elem_text:
+        # add | before first cell
+        elem_text = f"{elem_text}" if element.getprevious() is not None else f"| {elem_text}"
     # lists
     elif element.tag == "item" and elem_text:
         elem_text = f"- {elem_text}\n"
@@ -324,7 +327,7 @@ def process_element(element: _Element, returnlist: List[str], include_formatting
                     returnlist.append(f'{"|" * (max_span - cell_count)}\n')
                 # if this is a head row, draw the separator below
                 if element.xpath("./cell[@role='head']"):
-                    returnlist.append(f'\n{"---|" * max_span}\n')
+                    returnlist.append(f'\n|{"---|" * max_span}\n')
             else:
                 returnlist.append("\n")
         elif element.tag != "cell":
@@ -337,7 +340,7 @@ def process_element(element: _Element, returnlist: List[str], include_formatting
     # Common elements (Now processes end-tag logic correctly)
     if element.tag in NEWLINE_ELEMS and not element.xpath("ancestor::cell"):
         # spacing hack
-        returnlist.append("\n\u2424\n" if include_formatting else "\n")
+        returnlist.append("\n\u2424\n" if include_formatting and element.tag != 'row' else "\n")
     elif element.tag == "cell":
         returnlist.append(" | ")
     elif element.tag not in SPECIAL_FORMATTING:

--- a/trafilatura/xml.py
+++ b/trafilatura/xml.py
@@ -287,7 +287,7 @@ def replace_element_text(element: _Element, include_formatting: bool) -> str:
     # cells
     if element.tag == "cell" and elem_text and len(element) > 0:
         if element[0].tag == 'p':
-            elem_text = f"{elem_text} "
+            elem_text = f"{elem_text} " if element.getprevious() is not None else f"| {elem_text} "
     elif element.tag == 'cell' and elem_text:
         # add | before first cell
         elem_text = f"{elem_text}" if element.getprevious() is not None else f"| {elem_text}"


### PR DESCRIPTION
currently extracting markdown from web pages does not return proper markdown for tables. 
e.g., for page like https://www.formula1.com/en/latest/article/formula-1-qatar-airways-qatar-grand-prix-2024-timetable.2IVEFdWCCYlUGDNcfJo5pJ, current returned markdown is like:
```
FRIDAY 29th NOVEMBER | Local time | |
---|---|---|

Porsche Carrera Cup Middle East | Practice Session | 11:50 - 12:35 |

F1 Academy | First Practice Session | 13:00 - 13:40 |

FIA Formula 2 | Practice Session | 14:05 - 14:50 |
```

we would expect tables formatted like:
```
| FRIDAY 29th NOVEMBER | Local time | |
|---|---|---|
| Porsche Carrera Cup Middle East | Practice Session | 11:50 - 12:35 |
| F1 Academy | First Practice Session | 13:00 - 13:40 |
| FIA Formula 2 | Practice Session | 14:05 - 14:50 |
| Paddock Club | Paddock Club Track Tour | 15:00 - 15:50 |
...
```
which is more standard and compact.

