### PR TITLE
Fix eager doctype regex matching

### DIFF
--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -140,6 +140,13 @@ def test_input():
         == '<!DOCTYPE html>\n<html lang="en-US">\n<head/>\n<body/>\n</html>'
     )
 
+    htmlstring = '<!DOCTYPE html><html><head></head><body>Foo <br/> Bar</body></html>'
+    beginning = htmlstring[:50].lower()
+    assert (
+        repair_faulty_html(htmlstring, beginning)
+        == '<!DOCTYPE html><html><head></head><body>Foo <br/> Bar</body></html>\n'
+    )
+
     with pytest.raises(TypeError) as err:
         assert load_html(123) is None
     assert 'incompatible' in str(err.value)

--- a/trafilatura/utils.py
+++ b/trafilatura/utils.py
@@ -61,7 +61,7 @@ LOGGER = logging.getLogger(__name__)
 
 UNICODE_ALIASES = {'utf-8', 'utf_8'}
 
-DOCTYPE_TAG = re.compile("^< ?! ?DOCTYPE.+?/ ?>", re.I)
+DOCTYPE_TAG = re.compile("^< ?! ?DOCTYPE[^>]*/[^<]*>", re.I)
 FAULTY_HTML = re.compile(r"(<html.*?)\s*/>", re.I)
 HTML_STRIP_TAGS = re.compile(r'(<!--.*?-->|<[^>]*>)')
 


### PR DESCRIPTION
This fixes a bug encountered in the wild: repair_faulty_html() tries to match malformed doctype tags assuming the doctype to be followed by a newline. If there actually is no newline then the regex matches too eager, and parts of the document are removed erroneously.

A reduced test case is
`<!DOCTYPE html><html><head></head><body>Foo <br/> Bar</body></html>` which would be reduced to ` Bar</body></html>` without the fix.

This PR adds a reduced test case and tries to fix eagerness by keeping the regex in tag bounderies. pytest shows no regressions.