### PR TITLE
extraction: add extract_with_metadata method and ut

### DIFF
--- a/trafilatura/__init__.py
+++ b/trafilatura/__init__.py
@@ -13,7 +13,7 @@ __version__ = "2.0.0"
 import logging
 
 from .baseline import baseline, html2txt
-from .core import bare_extraction, extract
+from .core import bare_extraction, extract, extract_with_metadata
 from .downloads import fetch_response, fetch_url
 from .metadata import extract_metadata
 from .utils import load_html
@@ -25,6 +25,7 @@ __all__ = [
     "baseline",
     "extract",
     "extract_metadata",
+    "extract_with_metadata",
     "fetch_response",
     "fetch_url",
     "html2txt",

--- a/trafilatura/core.py
+++ b/trafilatura/core.py
@@ -577,6 +577,7 @@ def _internal_extraction(
         config: Any = DEFAULT_CONFIG,
         options: Optional[Extractor] = None,
 ) -> Optional[Document]:
+    '''Internal method to do the extraction'''
     _check_deprecation(no_fallback=no_fallback, as_dict=False, max_tree_size=max_tree_size)
 
     # regroup extraction options


### PR DESCRIPTION
Add extract_with_metadata method in core for scenarios which require separate metadata and extracted content to be both returned.

A few extra notes:
1. deprecated options like `no_fallback` and `max_tree_size` are removed in the new method.
2. `with_metadata` option is hard-coded to True and `only_with_metadata` is hard-coded to False to avoid confusion.