### PR TITLE
Detect code in pre-tag using indicators and fix code formatting issues

### DIFF
--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -354,15 +354,16 @@ def test_formatting():
 Here is a code sample:
 
 `import trafilatura`"""
-    my_document = html.fromstring('<html><body><article><h3>Title</h3><p>Here is a code sample:</p><code>import trafilatura\ntrafilatura.extract("")</code><p>Sometimes code is wrapped using <code>pre</code> and <code>code</code>:</p><pre><code>import trafilatura\ntrafilatura.extract("")</code></pre><p>Less often code is wrapped using just <code>pre</code>:</p><pre>\n    trafilatura.extract("")</pre></article></body></html>')
+    my_document = html.fromstring('<html><body><article><h3>Title</h3><p>Here is a code sample:</p><code><span>import</span> <span>something</span><br/>something.run("somewhere")</code><p>Sometimes code is wrapped using <code>pre</code> and <code>code</code>:</p><pre><code>import trafilatura\ntrafilatura.extract("")</code></pre><p>Less often code is wrapped using just <code>pre</code>:</p><pre>\n    trafilatura.extract("")</pre></article></body></html>')
     my_result = extract(my_document, output_format='txt', include_formatting=True, config=ZERO_CONFIG)
+    print(my_result)
     assert my_result == """### Title
 
 Here is a code sample:
 
 ```
-import trafilatura
-trafilatura.extract("")
+import something
+something.run("somewhere")
 ```
 Sometimes code is wrapped using `pre` and `code`:
 

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -354,7 +354,7 @@ def test_formatting():
 Here is a code sample:
 
 `import trafilatura`"""
-    my_document = html.fromstring('<html><body><article><h3>Title</h3><p>Here is a code sample:</p><code>import trafilatura\ntrafilatura.extract("")</code></p></article></body></html>')
+    my_document = html.fromstring('<html><body><article><h3>Title</h3><p>Here is a code sample:</p><code>import trafilatura\ntrafilatura.extract("")</code><p>Sometimes code is wrapped using <code>pre</code> and <code>code</code>:</p><pre><code>import trafilatura\ntrafilatura.extract("")</code></pre><p>Less often code is wrapped using just <code>pre</code>:</p><pre>\n    trafilatura.extract("")</pre></article></body></html>')
     my_result = extract(my_document, output_format='txt', include_formatting=True, config=ZERO_CONFIG)
     assert my_result == """### Title
 
@@ -362,6 +362,17 @@ Here is a code sample:
 
 ```
 import trafilatura
+trafilatura.extract("")
+```
+Sometimes code is wrapped using `pre` and `code`:
+
+```
+import trafilatura
+trafilatura.extract("")
+```
+Less often code is wrapped using just `pre`:
+
+```
 trafilatura.extract("")
 ```"""
 

--- a/trafilatura/htmlprocessing.py
+++ b/trafilatura/htmlprocessing.py
@@ -321,7 +321,7 @@ def convert_quotes(elem: _Element) -> None:
             code_flag = True
     elem.tag = "code" if code_flag else "quote"
 
-def _is_code_block(text: str | None) -> bool:
+def _is_code_block(text: Optional[str]) -> bool:
     "Check if the element text is part of a code block."
     if not text:
         return False

--- a/trafilatura/htmlprocessing.py
+++ b/trafilatura/htmlprocessing.py
@@ -321,7 +321,8 @@ def convert_quotes(elem: _Element) -> None:
             code_flag = True
     elem.tag = "code" if code_flag else "quote"
 
-def _is_code_block(text: str) -> bool:
+def _is_code_block(text: str | None) -> bool:
+    "Check if the element text is part of a code block."
     if not text:
         return False
     for indicator in CODE_INDICATORS:

--- a/trafilatura/htmlprocessing.py
+++ b/trafilatura/htmlprocessing.py
@@ -44,6 +44,8 @@ HTML_TAG_MAPPING = {v: k for k, v in REND_TAG_MAPPING.items()}
 
 PRESERVE_IMG_CLEANING = {"figure", "picture", "source"}
 
+CODE_INDICATORS = ["{", "(\"", "('", "\n    "]
+
 
 def tree_cleaning(tree: HtmlElement, options: Extractor) -> HtmlElement:
     "Prune the tree by discarding unwanted elements."
@@ -315,6 +317,8 @@ def convert_quotes(elem: _Element) -> None:
             code_flag = True
             for subelem in code_elems:
                 subelem.attrib.clear()
+        if elem.text and any([code_indicator in elem.text for code_indicator in CODE_INDICATORS]):
+            code_flag = True
     elem.tag = "code" if code_flag else "quote"
 
 

--- a/trafilatura/htmlprocessing.py
+++ b/trafilatura/htmlprocessing.py
@@ -317,10 +317,17 @@ def convert_quotes(elem: _Element) -> None:
             code_flag = True
             for subelem in code_elems:
                 subelem.attrib.clear()
-        if elem.text and any([code_indicator in elem.text for code_indicator in CODE_INDICATORS]):
+        if _is_code_block(elem.text):
             code_flag = True
     elem.tag = "code" if code_flag else "quote"
 
+def _is_code_block(text: str) -> bool:
+    if not text:
+        return False
+    for indicator in CODE_INDICATORS:
+        if indicator in text:
+            return True
+    return False
 
 def convert_headings(elem: _Element) -> None:
     "Add head tags and delete attributes."

--- a/trafilatura/xml.py
+++ b/trafilatura/xml.py
@@ -251,8 +251,8 @@ def validate_tei(xmldoc: _Element) -> bool:
 
 
 def replace_element_text(element: _Element, include_formatting: bool) -> str:
-    "Determine element text based on just the text of the element. One must deal with the tail separately."
     elem_text = element.text or ""
+    "Determine element text based on just the text of the element. One must deal with the tail separately."
     # handle formatting: convert to markdown
     if include_formatting and element.text:
         if element.tag == "head":
@@ -268,7 +268,11 @@ def replace_element_text(element: _Element, include_formatting: bool) -> str:
             if rend in HI_FORMATTING:
                 elem_text = f"{HI_FORMATTING[rend]}{elem_text}{HI_FORMATTING[rend]}"
         elif element.tag == "code":
-            if "\n" in element.text:
+            if "\n" in elem_text or element.xpath(".//lb"):  # Handle <br> inside <code>
+                # Convert <br> to \n within code blocks
+                for lb in element.xpath(".//lb"):
+                    elem_text = f"{elem_text}\n{lb.tail}"
+                    lb.getparent().remove(lb)
                 elem_text = f"```\n{elem_text}\n```\n"
             else:
                 elem_text = f"`{elem_text}`"

--- a/trafilatura/xml.py
+++ b/trafilatura/xml.py
@@ -35,6 +35,7 @@ TEI_DIV_SIBLINGS = {"p", "list", "table", "quote", "ab"}
 CONTROL_PARSER = XMLParser(remove_blank_text=True)
 
 NEWLINE_ELEMS = {'graphic', 'head', 'lb', 'list', 'p', 'quote', 'row', 'table'}
+SPECIAL_FORMATTING = {'code', 'del', 'head', 'hi', 'ref'}
 WITH_ATTRIBUTES = {'cell', 'row', 'del', 'graphic', 'head', 'hi', 'item', 'list', 'ref'}
 NESTING_WHITELIST = {"cell", "figure", "item", "note", "quote"}
 

--- a/trafilatura/xml.py
+++ b/trafilatura/xml.py
@@ -34,8 +34,7 @@ TEI_DIV_SIBLINGS = {"p", "list", "table", "quote", "ab"}
 
 CONTROL_PARSER = XMLParser(remove_blank_text=True)
 
-NEWLINE_ELEMS = {'code', 'graphic', 'head', 'lb', 'list', 'p', 'quote', 'row', 'table'}
-SPECIAL_FORMATTING = {'del', 'head', 'hi', 'ref'}
+NEWLINE_ELEMS = {'graphic', 'head', 'lb', 'list', 'p', 'quote', 'row', 'table'}
 WITH_ATTRIBUTES = {'cell', 'row', 'del', 'graphic', 'head', 'hi', 'item', 'list', 'ref'}
 NESTING_WHITELIST = {"cell", "figure", "item", "note", "quote"}
 
@@ -269,7 +268,7 @@ def replace_element_text(element: _Element, include_formatting: bool) -> str:
                 elem_text = f"{HI_FORMATTING[rend]}{elem_text}{HI_FORMATTING[rend]}"
         elif element.tag == "code":
             if "\n" in element.text:
-                elem_text = f"```\n{elem_text}\n```"
+                elem_text = f"```\n{elem_text}\n```\n"
             else:
                 elem_text = f"`{elem_text}`"
     # handle links


### PR DESCRIPTION
Tackles #775 and an issue mentioned in #553.

**Regarding #775** which mentions problems in detecting code blocks using just `<pre>`-tag:

`convert_quotes` is extended so that it uses a list of indicators to verify, if the element is a quote or a code block. If a code indicator is detected within the element, its expected to be a code block.
Suggested indicators to start with are: `{`, `("`, `('`, `\n    `

**Regarding #553:**
Quote: "btw. here is another bug (maybe) when extracting inline code block, a redundant '\n' was added after a inline code block now result"

I changed how the line break is added to `code` blocks. I removed `code` as "NEWLINE_ELEMS" which currently leads to the line break. Instead the line break is now added when converting `code` to text if its a multiline block.

While fixing this issue another problem arose. A space is added after inline code. I fixed this issue making `code` a "SPECIAL_FORMATTING" element.


**Issue with <lb> breaking code** is tackled, too.
Line breaks are converted to \n within code blocks. There might be an issue with spaces which definitely needs to be addressed as mentioned in #553.