### PR TITLE
Update README: fix /dependents links

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The extractor strikes a balance between limiting noise (precision) and
 including all valid parts (recall). It is **robust and reasonably fast**.
 
 Trafilatura is [widely used](https://trafilatura.readthedocs.io/en/latest/used-by.html)
-and integrated into [thousands of projects](https://github.com/adbar/trafilatura/network/dependents>)
+and integrated into [thousands of projects](https://github.com/adbar/trafilatura/network/dependents)
 by companies like HuggingFace, IBM, and Microsoft Research as well as institutions like
 the Allen Institute, Stanford, the Tokyo Institute of Technology, and
 the University of Munich.


### PR DESCRIPTION
The link had an extra `>` and led to a 404
Correct link: https://github.com/adbar/trafilatura/network/dependents 3.9k repositories, that's nice!