### PR TITLE
Changed code to handle potential empty string.

### DIFF
--- a/trafilatura/main_extractor.py
+++ b/trafilatura/main_extractor.py
@@ -376,7 +376,8 @@ def handle_table(table_elem: _Element, potential_tags: Set[str], options: Extrac
     for tr in table_elem.iter('tr'):
         total_colspans = 0
         for td in tr.iter(TABLE_ELEMS):
-            colspan = int(td.get("colspan", 1))
+            colspan = td.get("colspan", 1)
+            colspan = int(colspan) if colspan else 1
             diff_colspans.add(colspan)
             total_colspans += colspan
         max_cols = max(max_cols, total_colspans)


### PR DESCRIPTION
There are certain cases where the `colspan` attribute is mapped to an empty string and thus causes ValueErrors when trying to cast them to integers.

For example here:

```HTML
<table>
    <colgroup>
        <col style="width:25%;">
        <col style="width:25%;">
        <col style="width:25%;">
        <col style="width:25%;">
    </colgroup>
    <thead>
        <tr>
            <th rowspan="2" scope="col">Category</th>
            <th rowspan="2" scope="col">Regular Price (per person)</th>
            <th colspan="" scope="col">Online Discounted Price</th>
            <th colspan="" scope="col">On-site Discount Price</th>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>Adult</td>
            <td>₩69,000</td>
            <td class="cPurple fBold">₩33,100</td>
            <td class="cPurple fBold">₩32,500</td>
        </tr>
        <tr>
            <td>Teenager</td>
            <td>₩61,000</td>
            <td class="cPurple fBold">₩33,100</td>
            <td class="cPurple fBold">₩32,500</td>
        </tr>
        <tr>
            <td>Child</td>
            <td>₩53,000</td>
            <td class="cPurple fBold">₩33,100</td>
            <td class="cPurple fBold">₩32,500</td>
        </tr>
    </tbody>
</table>
```

The extra line that I added essentially checks to make sure that the result of `td.get("colspan")` is not an empty string, and if it is then make it default to 1.