### PR TITLE
fix: table handling and img tags inside tables

### DIFF
--- a/trafilatura/external.py
+++ b/trafilatura/external.py
@@ -46,7 +46,7 @@ def compare_extraction(tree: HtmlElement, backup_tree: HtmlElement, body: _Eleme
     '''Decide whether to choose own or external extraction
        based on a series of heuristics'''
     # bypass for recall
-    if options.focus == "recall" and len_text > options.min_extracted_size * 10:
+    if options.focus == "recall":
         return body, text, len_text
 
     use_readability, jt_result = False, False

--- a/trafilatura/htmlprocessing.py
+++ b/trafilatura/htmlprocessing.py
@@ -432,7 +432,7 @@ def convert_tags(
 HTML_CONVERSIONS = {
     "list": "ul",
     "item": "li",
-    "code": "pre",
+    "code": lambda elem: "pre" if elem.xpath('.//code') else "code",
     "quote": "blockquote",
     "head": lambda elem: f"h{int(elem.get('rend', 'h3')[1:])}",
     "lb": "br",

--- a/trafilatura/htmlprocessing.py
+++ b/trafilatura/htmlprocessing.py
@@ -436,7 +436,9 @@ HTML_CONVERSIONS = {
     "quote": "blockquote",
     "head": lambda elem: f"h{int(elem.get('rend', 'h3')[1:])}",
     "lb": "br",
-    "img": "graphic",
+    "graphic": "img",
+    "row": "tr",
+    "cell": lambda elem: "th" if elem.get("role") == "head" else "td",
     "ref": "a",
     "hi": lambda elem: HTML_TAG_MAPPING[elem.get("rend", "#i")],
 }
@@ -454,6 +456,8 @@ def convert_to_html(tree: _Element) -> _Element:
         # handle attributes
         if elem.tag == "a":
             elem.set("href", elem.attrib.pop("target", ""))
+        elif elem.tag == "img":
+            elem.set("src", elem.attrib.pop("src", ""))
         else:
             elem.attrib.clear()
     tree.tag = "body"

--- a/trafilatura/htmlprocessing.py
+++ b/trafilatura/htmlprocessing.py
@@ -179,7 +179,7 @@ def link_density_test_tables(element: HtmlElement) -> bool:
         return False
 
     elemlen = len(trim(element.text_content()))
-    if elemlen < 200:
+    if elemlen > 0 and elemlen < 200:
         return False
 
     linklen, elemnum, _, _ = collect_link_info(links_xpath)

--- a/trafilatura/main_extractor.py
+++ b/trafilatura/main_extractor.py
@@ -134,7 +134,12 @@ def process_nested_elements(child: _Element, new_child_elem: _Element, options: 
             if processed_subchild is not None:
                 new_child_elem.append(processed_subchild)
         elif subelem.tag == "table":
-            processed_subchild = handle_table(subelem, TAG_CATALOG, options)
+            potential_tags = set(TAG_CATALOG)
+            if options.images is True:
+                potential_tags.add('graphic')
+            if options.links is True:
+                potential_tags.add('ref')
+            processed_subchild = handle_table(subelem, potential_tags, options)
             if processed_subchild is not None:
                 new_child_elem.append(processed_subchild)
         else:

--- a/trafilatura/main_extractor.py
+++ b/trafilatura/main_extractor.py
@@ -133,6 +133,10 @@ def process_nested_elements(child: _Element, new_child_elem: _Element, options: 
             processed_subchild = handle_lists(subelem, options)
             if processed_subchild is not None:
                 new_child_elem.append(processed_subchild)
+        elif subelem.tag == "table":
+            processed_subchild = handle_table(subelem, TAG_CATALOG, options)
+            if processed_subchild is not None:
+                new_child_elem.append(processed_subchild)
         else:
             processed_subchild = handle_textnode(subelem, options, comments_fix=False)
             if processed_subchild is not None:
@@ -433,8 +437,8 @@ def handle_table(table_elem: _Element, potential_tags: Set[str], options: Extrac
                         define_newelem(processed_subchild, new_child_elem)
                     child.tag = "done"
             # add to tree
-            if new_child_elem.text or len(new_child_elem) > 0:
-                newrow.append(new_child_elem)
+            # if new_child_elem.text or len(new_child_elem) > 0:
+            newrow.append(new_child_elem)
         # beware of nested tables
         elif subelement.tag == "table":
             break
@@ -608,6 +612,8 @@ def _extract(tree: HtmlElement, options: Extractor) -> Tuple[_Element, str, Set[
         ptest = subtree.xpath('//p//text()')
         if options.focus == "precision":
             factor = 1
+        elif options.focus == "recall":
+            factor = 10
         else:
             factor = 3
         if not ptest or len(''.join(ptest)) < options.min_extracted_size * factor:  # type: ignore[attr-defined]

--- a/trafilatura/xpaths.py
+++ b/trafilatura/xpaths.py
@@ -46,7 +46,7 @@ BODY_XPATH = [XPath(x) for x in (
     or @role='article'])[1]""",
     '''(.//*[self::article or self::div or self::main or self::section][
     contains(@id, "content-main") or contains(@class, "content-main") or contains(@class, "content_main") or
-    contains(@id, "content-body") or contains(@class, "content-body") or contains(@id, "contentBody")
+    contains(@id, "content-body") or contains(@class, "content-body") or contains(@class, "conbody") or contains(@id, "conbody") or contains(@id, "contentBody")
     or contains(@class, "content__body") or contains(translate(@id, "CM","cm"), "main-content") or contains(translate(@class, "CM","cm"), "main-content")
     or contains(translate(@class, "CP","cp"), "page-content") or
     @id="content" or @class="content"])[1]''',

--- a/trafilatura/xpaths.py
+++ b/trafilatura/xpaths.py
@@ -26,7 +26,7 @@ BODY_XPATH = [XPath(x) for x in (
     contains(@class, "article__body") or @itemprop="articleBody" or
     contains(translate(@id, "B", "b"), "articlebody") or contains(translate(@class, "B", "b"), "articlebody")
     or @id="articleContent" or contains(@class, "ArticleContent") or
-    contains(@class, "page-content") or contains(@class, "text-content") or
+    contains(@class, "page-content") or contains(@class, "text-content") or contains(@class, "inner-content") or
     contains(@id, "body-text") or contains(@class, "body-text") or
     contains(@class, "article__container") or contains(@id, "art-content") or contains(@class, "art-content")][1]''',
     # (…)[1] = first occurrence


### PR DESCRIPTION
[fix: handle nested tables inside list component](https://github.com/adbar/trafilatura/commit/0aba6862c654a4a94887f6667adf838c69b32b9b) 
- fixes #633 by keeping empty cells inside tables as is to keep column structure consistent.
- Also additionally handles nested tables inside list components and allows texts inside divs to be extracted when `favor_recall` is set to True.

[fix: convert graphic, row and cell to html](https://github.com/adbar/trafilatura/commit/80fd02065229a2498ab92f5223f26ee61eede4ca)
- fixes #777 where graphic, row and cell tags were not properly converted to html
- seems like also fixed #396 as a side effect
