### PR TITLE
Added support to meta name image

### DIFF
--- a/trafilatura/metadata.py
+++ b/trafilatura/metadata.py
@@ -275,6 +275,9 @@ def examine_meta(tree: HtmlElement) -> Document:
             # site name
             elif name_attr in METANAME_PUBLISHER:
                 metadata.sitename = metadata.sitename or content_attr
+            # image    
+            elif name_attr in METANAME_IMAGE:
+                metadata.image = metadata.image or content_attr
             # twitter
             elif name_attr in TWITTER_ATTRS or "twitter:app:name" in name_attr:
                 backup_sitename = content_attr


### PR DESCRIPTION
Hey @adbar,

How are you?

I noticed that some websites are using the following tag to store the image, and it looks like this one was missing in the metadata:

```html
<meta name="twitter:image" content="https://images.jpg" />
```

Thanks.