### PR TITLE
[codex] Preserve inline refs in table cells

### DIFF
--- a/.github/workflows/dispatch-inkmark.yml
+++ b/.github/workflows/dispatch-inkmark.yml
@@ -1,0 +1,24 @@
+name: Dispatch Inkmark Rebuild
+
+on:
+  workflow_run:
+    workflows: ["Tests"]
+    types:
+      - completed
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'master' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger trafilatura rebuild in Inkmark
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.INKMARK_REPO_DISPATCH_TOKEN }}
+          repository: avhm/inkmark-monorepo
+          event-type: trafilatura-updated
+          client-payload: >-
+            {"trafilatura_sha":"${{ github.event.workflow_run.head_sha }}","source_repository":"${{ github.repository }}","source_branch":"${{ github.event.workflow_run.head_branch }}","source_run_id":"${{ github.event.workflow_run.id }}","source_run_url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}"}

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -26,13 +26,36 @@ jobs:
       - name: Fetch upstream
         run: |
           set -euo pipefail
+          fetch_with_retry() {
+            local remote="$1"
+            local branch="$2"
+            local max_attempts=5
+            local attempt=1
+
+            while true; do
+              if git fetch "$remote" "$branch"; then
+                return 0
+              fi
+
+              if [[ "$attempt" -ge "$max_attempts" ]]; then
+                echo "::error::git fetch $remote $branch failed after $max_attempts attempts"
+                return 1
+              fi
+
+              local sleep_seconds=$((attempt * 5))
+              echo "git fetch $remote $branch failed on attempt $attempt/$max_attempts; retrying in ${sleep_seconds}s..."
+              attempt=$((attempt + 1))
+              sleep "$sleep_seconds"
+            done
+          }
+
           if git remote get-url upstream >/dev/null 2>&1; then
             git remote set-url upstream https://github.com/adbar/trafilatura.git
           else
             git remote add upstream https://github.com/adbar/trafilatura.git
           fi
           git fetch origin master
-          git fetch upstream master
+          fetch_with_retry upstream master
 
       - name: Check whether upstream is ahead
         id: upstream

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,0 +1,105 @@
+name: Sync Upstream
+
+on:
+  schedule:
+    - cron: "17 * * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: sync-upstream-master
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync-upstream:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout master
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          ref: master
+
+      - name: Fetch upstream
+        run: |
+          set -euo pipefail
+          if git remote get-url upstream >/dev/null 2>&1; then
+            git remote set-url upstream https://github.com/adbar/trafilatura.git
+          else
+            git remote add upstream https://github.com/adbar/trafilatura.git
+          fi
+          git fetch origin master
+          git fetch upstream master
+
+      - name: Check whether upstream is ahead
+        id: upstream
+        run: |
+          set -euo pipefail
+          ahead="$(git rev-list --right-only --count master...upstream/master)"
+          short_sha="$(git rev-parse --short=12 upstream/master)"
+          {
+            echo "ahead=$ahead"
+            echo "short_sha=$short_sha"
+            echo "branch=automation/sync-upstream-$short_sha"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Nothing to sync
+        if: steps.upstream.outputs.ahead == '0'
+        run: echo "upstream/master is already merged into master"
+
+      - name: Configure git author
+        if: steps.upstream.outputs.ahead != '0'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Merge upstream/master into sync branch
+        if: steps.upstream.outputs.ahead != '0'
+        env:
+          BRANCH_NAME: ${{ steps.upstream.outputs.branch }}
+        run: |
+          set -euo pipefail
+          git checkout -B "$BRANCH_NAME" master
+          git merge --no-ff --no-edit upstream/master
+
+      - name: Push sync branch
+        if: steps.upstream.outputs.ahead != '0'
+        env:
+          BRANCH_NAME: ${{ steps.upstream.outputs.branch }}
+        run: |
+          set -euo pipefail
+          git push --force-with-lease origin "$BRANCH_NAME"
+
+      - name: Create or reuse pull request
+        if: steps.upstream.outputs.ahead != '0'
+        id: pull-request
+        env:
+          BRANCH_NAME: ${{ steps.upstream.outputs.branch }}
+          GH_TOKEN: ${{ github.token }}
+          SHORT_SHA: ${{ steps.upstream.outputs.short_sha }}
+        run: |
+          set -euo pipefail
+          pr_number="$(gh pr list --base master --head "$BRANCH_NAME" --json number --jq '.[0].number')"
+          if [[ -z "$pr_number" ]]; then
+            pr_url="$(gh pr create \
+              --base master \
+              --head "$BRANCH_NAME" \
+              --title "chore: sync upstream/master ($SHORT_SHA)" \
+              --body "Syncs \`upstream/master\` into \`master\` and relies on the existing test workflow before merge.")"
+            pr_number="${pr_url##*/}"
+          fi
+          echo "number=$pr_number" >> "$GITHUB_OUTPUT"
+
+      - name: Enable auto-merge
+        if: steps.upstream.outputs.ahead != '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.pull-request.outputs.number }}
+        run: |
+          set -euo pipefail
+          if ! gh pr merge --auto --merge "$PR_NUMBER"; then
+            echo "Auto-merge could not be enabled. Enable repository auto-merge if you want fully unattended upstream syncs." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,8 +91,20 @@ jobs:
         env:
           PROXY_TEST: ${{ matrix.proxy-test }}
 
+      - name: Check Codecov token availability
+        id: codecov-token
+        if: ${{ matrix.upload-coverage == 'true' }}
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        run: |
+          if [[ -n "${CODECOV_TOKEN}" ]]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Upload coverage to Codecov
-        if: ${{ matrix.upload-coverage == 'true' && secrets.CODECOV_TOKEN != '' }}
+        if: ${{ matrix.upload-coverage == 'true' && steps.codecov-token.outputs.available == 'true' }}
         uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,112 +9,94 @@ on:
   pull_request:
     branches: [ master ]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
-
-    runs-on: ${{ matrix.os }}
+    name: build (${{ matrix.python-version }}, ${{ matrix.variant }})
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
-        # https://github.com/actions/python-versions/blob/main/versions-manifest.json
-        python-version: ["3.9", "3.11", "3.13"]  # "3.14-dev"
-        env:
-          - MINIMAL: "true"
-            PROXY_TEST: "false"
-          - MINIMAL: "false"
-            PROXY_TEST: "true"
         include:
-          # custom python versions
-          - os: ubuntu-24.04
-            python-version: 3.8
-          - os: macos-13
-            python-version: 3.8
-          - os: macos-latest
-            python-version: "3.10"
-          - os: windows-latest
-            python-version: "3.10"
-          - os: ubuntu-latest
-            python-version: "3.12"
+          - python-version: "3.11"
+            variant: minimal
+            install-full: "false"
+            proxy-test: "false"
+            run-lint: "false"
+            run-mypy: "false"
+            upload-coverage: "false"
+          - python-version: "3.13"
+            variant: full
+            install-full: "true"
+            proxy-test: "true"
+            run-lint: "true"
+            run-mypy: "true"
+            upload-coverage: "true"
     services:
       socks_proxy:
-        image: ${{ matrix.os == 'ubuntu-latest' && 'serjs/go-socks5-proxy' || '' }}
+        image: serjs/go-socks5-proxy
+        env:
+          REQUIRE_AUTH: "false"
         ports:
           - 1080:1080
       socks_proxy_auth:
-        image: ${{ matrix.os == 'ubuntu-latest' && 'serjs/go-socks5-proxy' || '' }}
+        image: serjs/go-socks5-proxy
         env:
+          REQUIRE_AUTH: "true"
           PROXY_USER: user
           PROXY_PASSWORD: pass
         ports:
           - 1081:1080
 
     steps:
-    # Python and pip setup
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
+      - uses: actions/checkout@v5
 
-    - name: Upgrade pip
-      run: python -m pip install --upgrade pip
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
 
-    - name: Get pip cache dir
-      id: pip-cache
-      run: |
-        echo "::set-output name=dir::$(pip cache dir)"
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
 
-    - name: pip cache
-      uses: actions/cache@v4
-      with:
-        path: ${{ steps.pip-cache.outputs.dir }}
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
+      - name: Install dependencies
+        run: python -m pip install -e ".[dev]"
 
-    # package setup
-    - uses: actions/checkout@v4
+      - name: Install packages required by pycurl
+        if: ${{ matrix.install-full == 'true' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcurl4-gnutls-dev libgnutls28-dev
 
-    - name: Install dependencies
-      run: python -m pip install -e ".[dev]"
+      - name: Install full dependencies
+        if: ${{ matrix.install-full == 'true' }}
+        run: python -m pip install -e ".[all]"
 
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      - name: Lint with flake8
+        if: ${{ matrix.run-lint == 'true' }}
+        run: |
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
-    # pycurl installation fix
-    - name: Install packages required by pycurl
-      if: ${{ matrix.env.MINIMAL == 'false' }}
-      run: |
-        sudo apt-get update
-        sudo apt-get install libcurl4-gnutls-dev libgnutls28-dev
-    # alternatively: sudo apt-get install libcurl4-openssl-dev libssl-dev
+      - name: Type checking
+        if: ${{ matrix.run-mypy == 'true' }}
+        run: mypy -p trafilatura
 
-    - name: Install full dependencies
-      if: ${{ matrix.env.MINIMAL == 'false' }}
-      run: python -m pip install -e ".[all]"
+      - name: Test with pytest
+        run: python -m pytest --cov=./ --cov-report=xml
+        env:
+          PROXY_TEST: ${{ matrix.proxy-test }}
 
-    - name: Type checking
-      if: ${{ matrix.env.MINIMAL == 'false' && matrix.python-version == '3.13' }}
-      run: |
-        mypy -p trafilatura
-
-    - name: Test with pytest
-      run: |
-        python -m pytest --cov=./ --cov-report=xml
-      env:
-        PROXY_TEST: ${{ matrix.env.PROXY_TEST }}
-
-    # coverage
-    - name: Upload coverage to Codecov
-      if: ${{ matrix.env.MINIMAL == 'false' && matrix.python-version == '3.13' }}
-      uses: codecov/codecov-action@v4
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      with:
-        fail_ci_if_error: true
-        files: ./coverage.xml
-        verbose: true
+      - name: Upload coverage to Codecov
+        if: ${{ matrix.upload-coverage == 'true' && secrets.CODECOV_TOKEN != '' }}
+        uses: codecov/codecov-action@v5
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          fail_ci_if_error: true
+          files: ./coverage.xml
+          verbose: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,26 +14,8 @@ env:
 
 jobs:
   build:
-    name: build (${{ matrix.python-version }}, ${{ matrix.variant }})
+    name: build (3.13, full)
     runs-on: ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - python-version: "3.11"
-            variant: minimal
-            install-full: "false"
-            proxy-test: "false"
-            run-lint: "false"
-            run-mypy: "false"
-            upload-coverage: "false"
-          - python-version: "3.13"
-            variant: full
-            install-full: "true"
-            proxy-test: "true"
-            run-lint: "true"
-            run-mypy: "true"
-            upload-coverage: "true"
     services:
       socks_proxy:
         image: serjs/go-socks5-proxy
@@ -53,10 +35,10 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.13
         uses: actions/setup-python@v6
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.13"
           cache: pip
           cache-dependency-path: pyproject.toml
 
@@ -67,33 +49,28 @@ jobs:
         run: python -m pip install -e ".[dev]"
 
       - name: Install packages required by pycurl
-        if: ${{ matrix.install-full == 'true' }}
         run: |
           sudo apt-get update
           sudo apt-get install -y libcurl4-gnutls-dev libgnutls28-dev
 
       - name: Install full dependencies
-        if: ${{ matrix.install-full == 'true' }}
         run: python -m pip install -e ".[all]"
 
       - name: Lint with flake8
-        if: ${{ matrix.run-lint == 'true' }}
         run: |
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
       - name: Type checking
-        if: ${{ matrix.run-mypy == 'true' }}
         run: mypy -p trafilatura
 
       - name: Test with pytest
         run: python -m pytest --cov=./ --cov-report=xml
         env:
-          PROXY_TEST: ${{ matrix.proxy-test }}
+          PROXY_TEST: "true"
 
       - name: Check Codecov token availability
         id: codecov-token
-        if: ${{ matrix.upload-coverage == 'true' }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: |
@@ -104,7 +81,7 @@ jobs:
           fi
 
       - name: Upload coverage to Codecov
-        if: ${{ matrix.upload-coverage == 'true' && steps.codecov-token.outputs.available == 'true' }}
+        if: ${{ steps.codecov-token.outputs.available == 'true' }}
         uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -1900,6 +1900,21 @@ def test_inline_anchor_paragraph_merge():
     assert para.xpath('.//a')
 
 
+def test_inline_strong_retains_line_break():
+    """Line breaks inside bold/strong spans should survive as <br> nodes."""
+    html_input = """
+    <html><body><article>
+      <p><strong>“Hamnet”<br/></strong>This drama imagines how Shakespeare’s work might have been influenced.</p>
+    </article></body></html>
+    """
+    res = extract(html_input, output_format="html", include_formatting=True, config=ZERO_CONFIG)
+    doc = html.fromstring(res)
+    strong_nodes = doc.xpath('//p/strong')
+    assert strong_nodes, "Expected <strong> node in output"
+    strong_html = etree.tostring(strong_nodes[0], encoding="unicode")
+    assert "<br" in strong_html, "Expected <br> preserved inside <strong>"
+
+
 def test_html_figcaption_with_noise():
     """Figcaption text starting with CSS-like garbage is cleaned."""
     html_input = """

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -1905,6 +1905,38 @@ def test_html_figcaption_with_noise():
     assert 'css-1st60ou' not in res and 'margin-left:0.25rem' not in res and 'BAD(' not in res
 
 
+def test_inline_svg_preserved_when_images_requested():
+    html_input = """
+    <html><body><article>
+      <figure>
+        <svg viewBox="0 0 600 200" width="600" height="200" aria-label="Timeline">
+          <rect width="600" height="200" fill="#eee"></rect>
+          <text x="300" y="120" text-anchor="middle" fill="#222">Sample SVG</text>
+        </svg>
+        <figcaption>Inline SVG diagram</figcaption>
+      </figure>
+    </article></body></html>
+    """
+    xml_output = extract(
+        html_input,
+        output_format="xml",
+        include_images=True,
+        config=ZERO_CONFIG,
+    )
+    assert '<graphic data-type="svg"' in xml_output
+    assert 'data-inline-svg' in xml_output
+
+    html_output = extract(
+        html_input,
+        output_format="html",
+        include_images=True,
+        config=ZERO_CONFIG,
+    )
+    assert 'data:image/svg+xml;base64' in html_output
+    assert 'width="600"' in html_output and 'height="200"' in html_output
+    assert 'Inline SVG diagram' in html_output
+
+
 def test_audio_not_self_closed_does_not_swallow_content():
     """An <audio> wrapper should not swallow following content in either mode."""
     html_input = """

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -1882,6 +1882,24 @@ def test_html_figure_caption_sanitization_complex():
     assert 'Before Inside After' == ' '.join(cap.split())
 
 
+def test_inline_anchor_paragraph_merge():
+    """Inline-only anchor paragraphs should be merged back into prior paragraph."""
+    html_input = """
+    <html><body><article>
+      <p>Intro sentence without a full stop leads right into a</p>
+      <p><a href="https://example.com/link">link</a>. This continuation should remain inline.</p>
+    </article></body></html>
+    """
+    res = extract(html_input, output_format="html", include_links=True, config=ZERO_CONFIG)
+    doc = html.fromstring(res)
+    paras = doc.xpath('//p')
+    assert len(paras) == 1
+    para = paras[0]
+    assert 'link' in para.text_content()
+    assert 'This continuation should remain inline.' in para.text_content()
+    assert para.xpath('.//a')
+
+
 def test_html_figcaption_with_noise():
     """Figcaption text starting with CSS-like garbage is cleaned."""
     html_input = """

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -1890,6 +1890,7 @@ def test_html_figcaption_with_noise():
         <img src="a.jpg" alt="Alt"/>
         <figcaption>
           <style>.css-1st60ou{font-family:sans-serif;} .e15o9k8g0+.css-1st60ou{margin-left:0.25rem;}</style>
+          <script>BAD()</script>
           <span>Photograph: Reuters</span>
         </figcaption>
       </figure>
@@ -1898,7 +1899,10 @@ def test_html_figcaption_with_noise():
     res = extract(html_input, output_format="html", include_images=True, config=ZERO_CONFIG)
     doc = html.fromstring(res)
     cap = doc.xpath('//figure/figcaption')[0].text_content().strip()
+    # Caption must only contain visible text; no style/script contents
     assert 'Photograph: Reuters' == ' '.join(cap.split())
+    assert 'css-1st60ou' not in cap and 'margin-left:0.25rem' not in cap and 'BAD(' not in cap
+    assert 'css-1st60ou' not in res and 'margin-left:0.25rem' not in res and 'BAD(' not in res
 
 
 def test_audio_not_self_closed_does_not_swallow_content():
@@ -2006,3 +2010,11 @@ if __name__ == '__main__':
     test_lang_detection()
     test_is_probably_readerable()
     test_html_conversion()
+    # Media and figure/figcaption tests
+    test_html_figure_image_with_caption_html_output()
+    test_html_video_sources_with_caption_html_output()
+    test_html_figure_caption_sanitization_complex()
+    test_html_figcaption_with_noise()
+    test_audio_not_self_closed_does_not_swallow_content()
+    test_paragraph_splitting_for_figure()
+    test_audio_preserved_when_include_images()

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -1932,7 +1932,7 @@ def test_inline_svg_preserved_when_images_requested():
         include_images=True,
         config=ZERO_CONFIG,
     )
-    assert 'data:image/svg+xml;base64' in html_output
+    assert '<svg' in html_output
     assert 'width="600"' in html_output and 'height="200"' in html_output
     assert 'Inline SVG diagram' in html_output
 

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -1983,6 +1983,25 @@ def test_inline_anchor_paragraph_merge():
     assert para.xpath('.//a')
 
 
+def test_list_item_anchor_tail_space_is_preserved():
+    """Inline link tails inside list items should keep their leading space."""
+    html_input = """
+    <html><body><article>
+      <ol>
+        <li><a href="https://en.wikipedia.org/wiki/Mmap">Mmap</a> the input file to memory.</li>
+      </ol>
+    </article></body></html>
+    """
+    res = extract(html_input, output_format="html", include_links=True, config=ZERO_CONFIG)
+    doc = html.fromstring(res)
+    items = doc.xpath('//li')
+    assert len(items) == 1
+    item = items[0]
+    assert item.text_content() == "Mmap the input file to memory."
+    anchor = item.xpath('.//a')[0]
+    assert anchor.tail == " the input file to memory."
+
+
 def test_link_ids_are_preserved():
     """Anchor ids (e.g., footnote links) must survive extraction."""
     html_input = """

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -1140,7 +1140,9 @@ def test_table_processing():
         htmlstring, fast=True, output_format='xml', config=DEFAULT_CONFIG, include_links=True
     )
     result = processed.replace('\n', '').replace(' ', '')
-    assert """<table><row><cell>text<head>more_text</head></cell></row></table>""" in result
+    assert "<table><row>" in result
+    assert "<cell>text<head>more_text</head></cell>" in result
+    assert '<cell><p><reftarget="link">linktext</ref></p></cell>' in result
 
     table_cell_w_text_and_child = html.fromstring(
         "<table><tr><td>text<lb/><p>more text</p></td></tr></table>"
@@ -1156,8 +1158,8 @@ def test_table_processing():
         "<table><tr><td><ref target='test'>link</ref></td></tr></table>"
     )
     processed_table = handle_table(table_cell_with_link, TAG_CATALOG, options)
-    result = [child.tag for child in processed_table.find(".//cell").iterdescendants()]
-    assert result == ["p"]
+    result = etree.tostring(processed_table.find(".//cell"), encoding="unicode")
+    assert result == '<cell><p><ref target="test">link</ref></p></cell>'
     table_with_head = html.fromstring(
         """<table>
       <tr>
@@ -1981,6 +1983,40 @@ def test_inline_anchor_paragraph_merge():
     assert 'link' in para.text_content()
     assert 'This continuation should remain inline.' in para.text_content()
     assert para.xpath('.//a')
+
+
+def test_table_cell_inline_anchor_tail_is_preserved():
+    """Inline anchor tails inside table-cell paragraphs should survive HTML extraction."""
+    html_input = """
+    <html><body><table><tr><td>
+      <font size="2" face="verdana">
+        It was a test and is now an all out
+        <a href="https://example.com/war">war</a> on design.<br/><br/>
+        The present era starts here.
+      </font>
+    </td></tr></table></body></html>
+    """
+    res = extract(
+        html_input,
+        output_format="html",
+        include_links=True,
+        include_formatting=True,
+        include_images=True,
+        include_tables=True,
+        include_comments=False,
+        deduplicate=True,
+        fast=False,
+        favor_precision=True,
+        config=ZERO_CONFIG,
+    )
+    doc = html.fromstring(res)
+    cell = doc.xpath('//cell')[0]
+    assert "It was a test and is now an all out" in cell.text_content()
+    assert "war on design." in cell.text_content()
+    anchor = cell.xpath('.//a')[0]
+    assert anchor.get("href") == "https://example.com/war"
+    assert anchor.tail == " on design."
+    assert not cell.xpath('.//p[not(*) and not(normalize-space())]')
 
 
 def test_list_item_anchor_tail_space_is_preserved():

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -488,6 +488,66 @@ def test:
 ```""" == my_result
 
 
+def test_handle_paragraphs_preserves_inline_formatting_runs():
+    """Inline formatting inside a paragraph should stay in a single paragraph."""
+    options = DEFAULT_OPTIONS
+    options._add_config(ZERO_CONFIG)
+    paragraph = html.fromstring(
+        '<p>The gamble here was that because the regime would simply '
+        '<hi rend="#i"><hi rend="#b">collapse</hi></hi> on cue, the United States could remove '
+        'Iran’s regional threat <hi rend="#i">without</hi> having to commit to a major military operation '
+        'that might span weeks, disrupt global energy supplies, expand over the region, cost $200 billion '
+        'dollars and potentially require ground operations. Because <hi rend="#i">everyone</hi> knew that '
+        'result was <hi rend="#i"><hi rend="#b">worse than the status quo</hi></hi> and it would thus be '
+        '<hi rend="#i">really foolish</hi> to do that.</p>'
+    )
+    converted = handle_paragraphs(paragraph, TAG_CATALOG, options)
+    result = etree.tostring(converted, encoding="unicode")
+    assert result.count("<p") == 1
+    assert " ".join("".join(converted.itertext()).split()) == (
+        "The gamble here was that because the regime would simply collapse on cue, "
+        "the United States could remove Iran’s regional threat without having to "
+        "commit to a major military operation that might span weeks, disrupt global "
+        "energy supplies, expand over the region, cost $200 billion dollars and "
+        "potentially require ground operations. Because everyone knew that result was "
+        "worse than the status quo and it would thus be really foolish to do that."
+    )
+    assert '<hi rend="#i">everyone</hi> knew' in result
+    assert '<hi rend="#i">really foolish</hi> to do that.</p>' in result
+
+
+def test_inline_formatting_paragraph_does_not_split_html_output():
+    """Formatted inline spans should not be emitted as separate paragraphs."""
+    html_input = """
+    <html><body><article>
+      <p>The gamble here was that because the regime would simply <em><strong>collapse</strong></em> on cue, the United States could remove Iran’s regional threat <em>without</em> having to commit to a major military operation that might span weeks, disrupt global energy supplies, expand over the region, cost $200 billion dollars and potentially require ground operations. Because <em>everyone</em> knew that result was <em><strong>worse than the status quo</strong></em> and it would thus be <em>really foolish</em> to do that.</p>
+    </article></body></html>
+    """
+    result = extract(
+        html_input,
+        output_format="html",
+        include_formatting=True,
+        fast=True,
+        config=ZERO_CONFIG,
+    )
+    doc = html.fromstring(result)
+    paragraphs = doc.xpath("//p")
+    assert len(paragraphs) == 1
+    paragraph_html = etree.tostring(paragraphs[0], encoding="unicode")
+    assert " ".join(paragraphs[0].text_content().split()) == (
+        "The gamble here was that because the regime would simply collapse on cue, "
+        "the United States could remove Iran’s regional threat without having to "
+        "commit to a major military operation that might span weeks, disrupt global "
+        "energy supplies, expand over the region, cost $200 billion dollars and "
+        "potentially require ground operations. Because everyone knew that result was "
+        "worse than the status quo and it would thus be really foolish to do that."
+    )
+    assert "<i>everyone</i> knew" in paragraph_html
+    assert "<i>really foolish</i> to do that." in paragraph_html
+    assert "<i>everyone</i>knew" not in result
+    assert "<i>really foolish</i>to do that." not in result
+
+
 def test_extract_with_metadata():
     '''Test extract_with_metadata method'''
     url = 'http://aa.bb/cc.html'

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -2023,6 +2023,31 @@ def test_audio_not_self_closed_does_not_swallow_content():
     assert '</audio>' in res_media
 
 
+def test_anchor_wrapped_same_origin_images_survive_link_pruning():
+    """Anchor-only paragraphs with same-origin images should not be pruned by link-density cleanup."""
+    html_input = """
+    <html><body><article>
+      <p><a href="https://example.com/full"><img src="https://example.com/img/a.jpg" alt="A"></a></p>
+      <p><a href="https://cdn.other.com/full"><img src="https://cdn.other.com/img/b.jpg" alt="B"></a></p>
+      <p><a href="https://sub.example.com/full"><img src="https://sub.example.com/img/c.jpg" alt="C"></a></p>
+    </article></body></html>
+    """
+    res = extract(
+        html_input,
+        output_format="html",
+        include_images=True,
+        include_links=True,
+        config=ZERO_CONFIG,
+        url="https://example.com/post",
+    )
+    doc = html.fromstring(res)
+    imgs = doc.xpath('//img')
+    srcs = {img.get('src') for img in imgs}
+    assert 'https://example.com/img/a.jpg' in srcs, "expected same-origin image to survive"
+    assert 'https://sub.example.com/img/c.jpg' in srcs, "expected subdomain image to survive"
+    assert 'https://cdn.other.com/img/b.jpg' not in srcs, "external image should still be pruned"
+
+
 def test_paragraph_splitting_for_figure():
     """A <figure> inside a paragraph should result in two <p> blocks around it in HTML output."""
     html_input = """

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -548,6 +548,24 @@ def test_inline_formatting_paragraph_does_not_split_html_output():
     assert "<i>really foolish</i>to do that." not in result
 
 
+def test_handle_paragraphs_keeps_wrapped_formatting_with_link_text():
+    """Paragraphs wrapped in formatting should keep descendant text and links."""
+    options = DEFAULT_OPTIONS
+    options._add_config(ZERO_CONFIG)
+    paragraph = html.fromstring(
+        '<p><hi rend="#i"><hi rend="#b">Stream und Anmeldung<lb/></hi>'
+        'Die Tagung wird gestreamt. Alle weiteren Einzelheiten bitten wir direkt den '
+        '<ref target="http://example.org/info">Seiten der Stiftung</ref> zu entnehmen. '
+        'Hier geht zur <ref target="http://example.org/signup">Anmeldung</ref>.</hi></p>'
+    )
+    converted = handle_paragraphs(paragraph, TAG_CATALOG, options)
+    assert converted is not None
+    result = etree.tostring(converted, encoding="unicode")
+    assert "Stream und Anmeldung" in result
+    assert "Die Tagung wird gestreamt." in result
+    assert "Hier geht zur Anmeldung." in result
+
+
 def test_extract_with_metadata():
     '''Test extract_with_metadata method'''
     url = 'http://aa.bb/cc.html'

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -543,7 +543,7 @@ def test_extract_with_metadata():
 
 def test_external():
     '''Test external components'''
-    options = DEFAULT_OPTIONS
+    options = Extractor()
     options.tables = True
     # remove unwanted elements
     mydoc = html.fromstring('<html><body><footer>Test text</footer></body></html>')
@@ -575,7 +575,12 @@ def test_external():
     assert extract(teststring, fast=True, include_tables=False) == ''
     assert extract(teststring, fast=False, include_tables=False) == ''
     # invalid XML attributes: namespace colon in attribute key (issue #375). Those attributes should be stripped
-    bad_xml = 'Testing<ul style="" padding:1px; margin:15px""><b>Features:</b> <li>Saves the cost of two dedicated phone lines.</li> al station using Internet or cellular technology.</li> <li>Requires no change to the existing Fire Alarm Control Panel configuration. The IPGSM-4G connects directly to the primary and secondary telephone ports.</li>'
+    bad_xml = (
+        '<html><body>Testing<ul bad:attr="" style="margin:15px">'
+        '<li><b>Features:</b> Saves the cost of two dedicated phone lines.</li>'
+        "<li>Requires no change to the existing Fire Alarm Control Panel configuration.</li>"
+        "</ul></body></html>"
+    )
     res = extract(bad_xml, output_format='xml')
     assert "Features" in res
 
@@ -1010,7 +1015,7 @@ def test_precision_recall():
 
 
 def test_table_processing():
-    options = DEFAULT_OPTIONS
+    options = Extractor()
     table_simple_cell = html.fromstring(
         "<table><tr><td>cell1</td><td>cell2</td></tr><tr><td>cell3</td><td>cell4</td></tr></table>"
     )
@@ -1070,7 +1075,7 @@ def test_table_processing():
         == "<table><row><cell>text<p>more text</p></cell></row></table>"
     )
     table_cell_with_link = html.fromstring(
-        "<table><tr><td><ref='test'>link</ref></td></tr></table>"
+        "<table><tr><td><ref target='test'>link</ref></td></tr></table>"
     )
     processed_table = handle_table(table_cell_with_link, TAG_CATALOG, options)
     result = [child.tag for child in processed_table.find(".//cell").iterdescendants()]

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -1900,6 +1900,35 @@ def test_inline_anchor_paragraph_merge():
     assert para.xpath('.//a')
 
 
+def test_link_ids_are_preserved():
+    """Anchor ids (e.g., footnote links) must survive extraction."""
+    html_input = """
+    <html><body><article>
+      <p>
+        Agents are learning to talk and coordinate, as noted in
+        <a id="footnote-13-178703143"
+           href="https://www.thetimes.blog/p/agents-are-learning-to-talk#footnote-anchor-13-178703143"
+           class="footnote-number">13</a>,
+        which links to the supporting footnote.
+      </p>
+    </article></body></html>
+    """
+    res = extract(
+        html_input,
+        output_format="html",
+        include_links=True,
+        include_formatting=True,
+        config=ZERO_CONFIG,
+    )
+    doc = html.fromstring(res)
+    anchors = doc.xpath('//a[@id="footnote-13-178703143"]')
+    assert anchors, "expected footnote anchor id to be preserved"
+    anchor = anchors[0]
+    assert anchor.get("href") == (
+        "https://www.thetimes.blog/p/agents-are-learning-to-talk#footnote-anchor-13-178703143"
+    )
+
+
 def test_inline_strong_retains_line_break():
     """Line breaks inside bold/strong spans should survive as <br> nodes."""
     html_input = """

--- a/trafilatura/core.py
+++ b/trafilatura/core.py
@@ -22,7 +22,7 @@ from .htmlprocessing import (
     prune_unwanted_nodes,
     tree_cleaning,
 )
-from .main_extractor import extract_comments, extract_content
+from .main_extractor import extract_comments, extract_content, merge_inline_anchor_paragraphs
 from .metadata import Document, extract_metadata
 from .settings import DEFAULT_CONFIG, Extractor, use_config
 from .utils import (
@@ -272,6 +272,7 @@ def bare_extraction(
 
         # convert tags, the rest does not work without conversion
         cleaned_tree = convert_tags(cleaned_tree, options, options.url or document.url)
+        merge_inline_anchor_paragraphs(cleaned_tree)
 
         # comments first, then remove
         if options.comments:

--- a/trafilatura/downloads.py
+++ b/trafilatura/downloads.py
@@ -32,7 +32,14 @@ from courlan import UrlStore
 from courlan.network import redirection_test
 
 from .settings import DEFAULT_CONFIG, Extractor
-from .utils import URL_BLACKLIST_REGEX, decode_file, is_acceptable_length, make_chunks
+from .utils import (
+    HAS_BROTLI,
+    HAS_ZSTD,
+    URL_BLACKLIST_REGEX,
+    decode_file,
+    is_acceptable_length,
+    make_chunks,
+)
 
 try:
     from urllib3.contrib.socks import SOCKSProxyManager
@@ -72,7 +79,25 @@ def create_pool(**args: Any) -> Union[urllib3.PoolManager, Any]:
     return manager_class(**manager_args, **args)  # type: ignore[arg-type]
 
 
-DEFAULT_HEADERS = urllib3.util.make_headers(accept_encoding=True)  # type: ignore[no-untyped-call]
+def _build_default_headers() -> Dict[str, str]:
+    "Create default request headers with optional compression support."
+    headers = urllib3.util.make_headers(accept_encoding=True)  # type: ignore[no-untyped-call]
+    encodings = headers.get("accept-encoding", "").split(",")
+    available = {encoding.strip() for encoding in encodings if encoding.strip()}
+    if HAS_BROTLI:
+        available.add("br")
+    if HAS_ZSTD:
+        available.add("zstd")
+    if available:
+        headers["accept-encoding"] = ",".join(
+            encoding
+            for encoding in ("deflate", "gzip", "br", "zstd")
+            if encoding in available
+        )
+    return headers
+
+
+DEFAULT_HEADERS = _build_default_headers()
 USER_AGENT = (
     "trafilatura/" + version("trafilatura") + " (+https://github.com/adbar/trafilatura)"
 )

--- a/trafilatura/external.py
+++ b/trafilatura/external.py
@@ -27,7 +27,7 @@ LOGGER = logging.getLogger(__name__)
 JT_STOPLIST = None
 
 SANITIZED_XPATH = './/aside|.//audio|.//button|.//fieldset|.//figure|.//footer|.//iframe|.//input|.//label|.//link|.//nav|.//noindex|.//noscript|.//object|.//option|.//select|.//source|.//svg|.//time'
-MEDIA_TAGS = {"audio", "video", "figure", "source", "track", "picture"}
+MEDIA_TAGS = {"audio", "video", "figure", "source", "track", "picture", "svg"}
 
 
 def try_readability(htmlinput: HtmlElement) -> HtmlElement:

--- a/trafilatura/htmlprocessing.py
+++ b/trafilatura/htmlprocessing.py
@@ -47,6 +47,8 @@ PRESERVE_IMG_CLEANING = {"figure", "picture", "source", "audio", "video", "track
 
 CODE_INDICATORS = ["{", "(\"", "('", "\n    "]
 
+# Remove CSS-like garbage sequences at the beginning of captions
+
 
 def tree_cleaning(tree: HtmlElement, options: Extractor) -> HtmlElement:
     "Prune the tree by discarding unwanted elements."
@@ -620,6 +622,9 @@ def convert_to_html(tree: _Element) -> _Element:
                 if s.get("media"):
                     sattrs["media"] = s["media"]
                 SubElement(media_el, "source", **sattrs)
+            # ensure non-selfclosing tags in XML serialization
+            if len(media_el) == 0:
+                media_el.text = ""
             replacement = wrap_in_figure(media_el)
 
         # replace in tree

--- a/trafilatura/htmlprocessing.py
+++ b/trafilatura/htmlprocessing.py
@@ -559,7 +559,7 @@ def convert_tags(
             if caption_el is not None:
                 # drop garbage elements inside caption (e.g., style/script)
                 for junk in caption_el.xpath('.//style|.//script|.//noscript|.//link|.//meta|.//iframe|.//object|.//svg'):
-                    delete_element(junk, keep_tail=False)
+                    delete_element(junk, keep_tail=True)
             caption = " ".join(caption_el.itertext()).strip() if caption_el is not None else ""
             if caption_el is not None and caption_el.getparent() is not None:
                 caption_el.getparent().remove(caption_el)

--- a/trafilatura/htmlprocessing.py
+++ b/trafilatura/htmlprocessing.py
@@ -427,6 +427,10 @@ def convert_tags(
             # extract caption text if present
             cap_nodes = fig.xpath('.//figcaption')
             caption_el = cap_nodes[0] if cap_nodes else None
+            if caption_el is not None:
+                # drop garbage elements inside caption (e.g., style/script)
+                for junk in caption_el.xpath('.//style|.//script|.//noscript|.//link|.//meta|.//iframe|.//object|.//svg'):
+                    delete_element(junk, keep_tail=False)
             caption = " ".join(caption_el.itertext()).strip() if caption_el is not None else ""
             if caption_el is not None and caption_el.getparent() is not None:
                 caption_el.getparent().remove(caption_el)

--- a/trafilatura/htmlprocessing.py
+++ b/trafilatura/htmlprocessing.py
@@ -509,12 +509,16 @@ def convert_link(elem: HtmlElement, base_url: Optional[str]) -> None:
     "Replace link tags and href attributes, delete the rest."
     elem.tag = "ref"
     target = elem.get("href")  # defaults to None
+    link_id = elem.get("id")
     elem.attrib.clear()
     if target:
         # convert relative URLs
         if base_url:
             target = fix_relative_urls(base_url, target)
         elem.set("target", target)
+    if link_id:
+        # Preserve anchor IDs (e.g., footnote targets) for round-trip output.
+        elem.set("id", link_id)
 
 
 def convert_tags(

--- a/trafilatura/htmlprocessing.py
+++ b/trafilatura/htmlprocessing.py
@@ -911,9 +911,9 @@ def convert_to_html(tree: _Element) -> _Element:
             p_before = Element("p")
             p_before.text = p.text
             for _ in range(idx_fig):
-                child = p[0]
-                p.remove(child)
-                p_before.append(child)
+                left_child: _Element = p[0]
+                p.remove(left_child)
+                p_before.append(left_child)
             # right part
             p_after = Element("p")
             # figure tail belongs to the right paragraph
@@ -922,9 +922,9 @@ def convert_to_html(tree: _Element) -> _Element:
                 fig.tail = None
             # move remaining children to right paragraph
             while len(p) > 0:
-                child = p[0]
-                p.remove(child)
-                p_after.append(child)
+                right_child: _Element = p[0]
+                p.remove(right_child)
+                p_after.append(right_child)
 
             # insert p_before, fig, p_after around original p
             grand = p.getparent()

--- a/trafilatura/htmlprocessing.py
+++ b/trafilatura/htmlprocessing.py
@@ -6,6 +6,7 @@ Functions to process nodes in HTML code.
 import base64
 import logging
 import re
+from urllib.parse import urlparse
 
 from copy import deepcopy
 from typing import List, Optional, Tuple
@@ -305,14 +306,19 @@ def delete_by_link_density(
     tagname: str,
     backtracking: bool = False,
     favor_precision: bool = False,
+    base_url: Optional[str] = None,
 ) -> HtmlElement:
     """Determine the link density of elements with respect to their length,
     and remove the elements identified as boilerplate."""
     deletions = []
     len_threshold = 200 if favor_precision else 100
     depth_threshold = 1 if favor_precision else 3
+    base_host = _safe_host(base_url)
 
     for elem in subtree.iter(tagname):
+        if base_host and _has_same_origin_media(elem, base_host):
+            # Keep media-only blocks when the media is hosted on the same origin/subdomain.
+            continue
         elemtext = trim(elem.text_content())
         result, templist = link_density_test(elem, elemtext, favor_precision)
         if result or (
@@ -329,6 +335,36 @@ def delete_by_link_density(
         delete_element(elem)
 
     return subtree
+
+
+def _safe_host(url: Optional[str]) -> Optional[str]:
+    if not url:
+        return None
+    try:
+        parsed = urlparse(url)
+        return parsed.hostname.lower() if parsed.hostname else None
+    except Exception:
+        return None
+
+
+def _host_matches(base_host: str, other: str) -> bool:
+    other = other.lower()
+    return other == base_host or other.endswith("." + base_host)
+
+
+def _has_same_origin_media(elem: HtmlElement, base_host: str) -> bool:
+    """Return True if the element contains a graphic pointing to the same origin/subdomain."""
+    for graphic in elem.xpath(".//graphic[@src]"):
+        src = graphic.get("src")
+        if not src:
+            continue
+        try:
+            host = urlparse(src).hostname
+        except Exception:
+            host = None
+        if host and _host_matches(base_host, host):
+            return True
+    return False
 
 
 def _has_math_markup(elem: _Element) -> bool:

--- a/trafilatura/htmlprocessing.py
+++ b/trafilatura/htmlprocessing.py
@@ -423,7 +423,8 @@ def handle_textnode(
     # filter content
     # or not re.search(r'\w', element.text):  # text_content()?
     has_math = _has_math_markup(elem)
-    if not has_math and not elem.text and textfilter(elem):
+    has_graphic = elem.tag == "graphic" or elem.find(".//graphic") is not None
+    if not has_math and not has_graphic and not elem.text and textfilter(elem):
         return None
     if options.dedup and duplicate_test(elem, options):
         return None

--- a/trafilatura/htmlprocessing.py
+++ b/trafilatura/htmlprocessing.py
@@ -33,7 +33,7 @@ from .settings import (
     MANUALLY_CLEANED,
     MANUALLY_STRIPPED,
 )
-from .utils import textfilter, trim, is_image_element
+from .utils import text_chars_test, textfilter, trim, is_image_element
 from .xml import META_ATTRIBUTES, delete_element
 
 
@@ -424,7 +424,16 @@ def handle_textnode(
     # or not re.search(r'\w', element.text):  # text_content()?
     has_math = _has_math_markup(elem)
     has_graphic = elem.tag == "graphic" or elem.find(".//graphic") is not None
-    if not has_math and not has_graphic and not elem.text and textfilter(elem):
+    has_text_content = (
+        elem.tag in ("hi", "ref")
+        and text_chars_test("".join(elem.itertext()))
+    )
+    if (
+        not has_math
+        and not has_graphic
+        and not has_text_content
+        and textfilter(elem)
+    ):
         return None
     if options.dedup and duplicate_test(elem, options):
         return None

--- a/trafilatura/main_extractor.py
+++ b/trafilatura/main_extractor.py
@@ -510,11 +510,11 @@ def handle_image(element: Optional[_Element], options: Optional[Extractor] = Non
         for attr in ("width", "height", "caption", "alt", "title"):
             if element.get(attr):
                 processed_element.set(attr, element.get(attr, ""))
-    elif dtype == "katex":
+    elif dtype in ("katex", "mathml"):
         inline_html = element.get("data-inline-html")
         if not inline_html:
             return None
-        processed_element.set("data-type", "katex")
+        processed_element.set("data-type", "mathml")
         processed_element.set("data-inline-html", inline_html)
         if display := element.get("data-display"):
             processed_element.set("data-display", display)

--- a/trafilatura/main_extractor.py
+++ b/trafilatura/main_extractor.py
@@ -495,6 +495,16 @@ def handle_image(element: Optional[_Element], options: Optional[Extractor] = Non
             else:
                 link = re.sub(r"^//", "http://", link)
             processed_element.set("src", link)
+    elif dtype == "svg":
+        inline_data = element.get("data-inline-svg")
+        if not inline_data:
+            return None
+        processed_element.set("data-type", "svg")
+        processed_element.set("data-inline-svg", inline_data)
+        processed_element.set("src", f"data:image/svg+xml;base64,{inline_data}")
+        for attr in ("width", "height", "caption", "alt", "title"):
+            if element.get(attr):
+                processed_element.set(attr, element.get(attr, ""))
     else:
         # Audio/Video: keep known attributes without enforcing image file suffix
         for k, v in element.attrib.items():

--- a/trafilatura/main_extractor.py
+++ b/trafilatura/main_extractor.py
@@ -360,9 +360,14 @@ def handle_paragraphs(element: _Element, potential_tags: Set[str], options: Extr
             # handle formatting
             newsub = Element(child.tag)
             if processed_child.tag in P_FORMATTING:
+                preserved_children = []
                 # check depth and clean
                 if len(processed_child) > 0:
-                    for item in processed_child:  # children are lists
+                    for item in list(processed_child):  # children are lists
+                        if item.tag == "lb":
+                            preserved_children.append(deepcopy(item))
+                            item.tag = "done"
+                            continue
                         if text_chars_test(item.text) is True:
                             item.text = " " + item.text  # type: ignore[operator]
                         strip_tags(processed_child, item.tag)
@@ -372,6 +377,9 @@ def handle_paragraphs(element: _Element, potential_tags: Set[str], options: Extr
                 elif child.tag == "ref":
                     if child.get("target") is not None:
                         newsub.set("target", child.get("target", ""))
+                if preserved_children:
+                    for preserved in preserved_children:
+                        newsub.append(preserved)
             # handle line breaks
             # elif processed_child.tag == 'lb':
             #    try:

--- a/trafilatura/main_extractor.py
+++ b/trafilatura/main_extractor.py
@@ -36,6 +36,7 @@ CODES_QUOTES = {'code', 'quote'}
 NOT_AT_THE_END = {'head', 'ref'}
 INLINE_ONLY_TAGS = {'ref', 'hi', 'span', 'code', 'lb', 'del', 'em', 'strong', 'sub', 'sup', 'b', 'i'}
 SENTENCE_TERMINATORS = ('.', '!', '?', ';', '…', ')', '"', "'", ']', '}', '»', '”', '’')
+COPYABLE_INLINE_OUTPUT = {'code', 'del', 'graphic', 'hi', 'lb', 'ref'}
 
 
 def _log_event(msg: str, tag: Any, text: Optional[Union[bytes, str]]) -> None:
@@ -72,7 +73,12 @@ def handle_titles(element: _Element, options: Extractor) -> Optional[_Element]:
 def handle_formatting(element: _Element, options: Extractor) -> Optional[_Element]:
     '''Process formatting elements (b, i, etc. converted to hi) found
        outside of paragraphs'''
-    formatting = process_node(element, options)
+    formatting = handle_textnode(
+        element,
+        options,
+        comments_fix=False,
+        preserve_spaces=True,
+    )
     if formatting is None:  #  and len(element) == 0
         return None
 
@@ -262,11 +268,19 @@ def is_text_element(elem: _Element) -> bool:
     return elem is not None and text_chars_test(''.join(elem.itertext())) is True
 
 
+def _has_copyable_output_children(processed_elem: _Element) -> bool:
+    "Copy processed nodes only when their nested markup is part of the extractor output vocabulary."
+    if len(processed_elem) == 0:
+        return False
+    descendant_tags = {child.tag for child in processed_elem.iterdescendants()}
+    return descendant_tags.issubset(COPYABLE_INLINE_OUTPUT)
+
+
 def define_newelem(processed_elem: _Element, orig_elem: _Element) -> None:
     "Create a new sub-element if necessary."
     if processed_elem is None:
         return
-    if _has_math_markup(processed_elem):
+    if _has_math_markup(processed_elem) or _has_copyable_output_children(processed_elem):
         new_child = deepcopy(processed_elem)
         orig_elem.append(new_child)
         return

--- a/trafilatura/main_extractor.py
+++ b/trafilatura/main_extractor.py
@@ -239,7 +239,12 @@ def process_nested_elements(child: _Element, new_child_elem: _Element, options: 
             if processed_subchild is not None:
                 new_child_elem.append(processed_subchild)
         else:
-            processed_subchild = handle_textnode(subelem, options, comments_fix=False)
+            processed_subchild = handle_textnode(
+                subelem,
+                options,
+                comments_fix=False,
+                preserve_spaces=True,
+            )
             if processed_subchild is not None:
                 add_sub_element(new_child_elem, subelem, processed_subchild)
         subelem.tag = "done"

--- a/trafilatura/main_extractor.py
+++ b/trafilatura/main_extractor.py
@@ -177,6 +177,21 @@ def add_sub_element(new_child_elem: _Element, subelem: _Element, processed_subch
         sub_child_elem.set(attr, subelem.attrib[attr])
 
 
+def _xml_compatible_text(value: Optional[str]) -> Optional[str]:
+    "Drop control characters that libxml refuses in text/tail assignments."
+    if value is None:
+        return None
+    cleaned = "".join(
+        char
+        for char in value
+        if char in ("\t", "\n", "\r")
+        or 0x20 <= ord(char) <= 0xD7FF
+        or 0xE000 <= ord(char) <= 0xFFFD
+        or 0x10000 <= ord(char) <= 0x10FFFF
+    )
+    return cleaned or None
+
+
 def process_nested_elements(child: _Element, new_child_elem: _Element, options: Extractor) -> None:
     "Iterate through an element child and rewire its descendants."
     new_child_elem.text = child.text
@@ -401,7 +416,8 @@ def handle_paragraphs(element: _Element, potential_tags: Set[str], options: Extr
             #        newsub.tail = processed_child.text + processed_child.tail
             #    else:
             #        newsub.tail = processed_child.text
-            newsub.text, newsub.tail = processed_child.text, processed_child.tail
+            newsub.text = _xml_compatible_text(processed_child.text)
+            newsub.tail = _xml_compatible_text(processed_child.tail)
 
             if processed_child.tag == 'graphic':
                 image_elem = handle_image(processed_child, options)

--- a/trafilatura/main_extractor.py
+++ b/trafilatura/main_extractor.py
@@ -377,6 +377,9 @@ def handle_paragraphs(element: _Element, potential_tags: Set[str], options: Extr
                 elif child.tag == "ref":
                     if child.get("target") is not None:
                         newsub.set("target", child.get("target", ""))
+                    # Preserve anchor ids (e.g., footnote links) so in-document jumps still work.
+                    if child.get("id") is not None:
+                        newsub.set("id", child.get("id", ""))
                 if preserved_children:
                     for preserved in preserved_children:
                         newsub.append(preserved)

--- a/trafilatura/main_extractor.py
+++ b/trafilatura/main_extractor.py
@@ -686,9 +686,27 @@ def prune_unwanted_sections(tree: HtmlElement, potential_tags: Set[str], options
             tree = prune_unwanted_nodes(tree, PRECISION_DISCARD_XPATH)
     # remove elements by link density, several passes
     for _ in range(2):
-        tree = delete_by_link_density(tree, 'div', backtracking=True, favor_precision=favor_precision)
-        tree = delete_by_link_density(tree, 'list', backtracking=False, favor_precision=favor_precision)
-        tree = delete_by_link_density(tree, 'p', backtracking=False, favor_precision=favor_precision)
+        tree = delete_by_link_density(
+            tree,
+            'div',
+            backtracking=True,
+            favor_precision=favor_precision,
+            base_url=options.url,
+        )
+        tree = delete_by_link_density(
+            tree,
+            'list',
+            backtracking=False,
+            favor_precision=favor_precision,
+            base_url=options.url,
+        )
+        tree = delete_by_link_density(
+            tree,
+            'p',
+            backtracking=False,
+            favor_precision=favor_precision,
+            base_url=options.url,
+        )
     # tables
     if 'table' in potential_tags or favor_precision:
         # tree = delete_by_link_density(tree, 'table', backtracking=False, favor_precision=favor_precision)

--- a/trafilatura/main_extractor.py
+++ b/trafilatura/main_extractor.py
@@ -192,6 +192,44 @@ def _xml_compatible_text(value: Optional[str]) -> Optional[str]:
     return cleaned or None
 
 
+def _needs_text_join(existing: str, incoming: str) -> bool:
+    "Determine if a space is needed when gluing two inline text runs together."
+    if not existing or not incoming:
+        return False
+    return (
+        not existing[-1].isspace()
+        and not incoming[0].isspace()
+        and incoming[0] not in ",.;:!?)]}"
+    )
+
+
+def _append_paragraph_text(processed_element: _Element, text: Optional[str]) -> None:
+    "Append text to a paragraph, preserving child order and simple spacing."
+    text = _xml_compatible_text(text)
+    if text is None:
+        return
+    if len(processed_element) > 0:
+        last_child = processed_element[-1]
+        existing_tail = last_child.tail or ""
+        if _needs_text_join(existing_tail, text):
+            last_child.tail = f"{existing_tail} {text}"
+        else:
+            last_child.tail = f"{existing_tail}{text}"
+        return
+    existing_text = processed_element.text or ""
+    if _needs_text_join(existing_text, text):
+        processed_element.text = f"{existing_text} {text}"
+    else:
+        processed_element.text = f"{existing_text}{text}"
+
+
+def _mark_subtree_done(element: _Element) -> None:
+    "Mark an element and all descendants as consumed by the extractor."
+    for descendant in element.iterdescendants():
+        descendant.tag = "done"
+    element.tag = "done"
+
+
 def process_nested_elements(child: _Element, new_child_elem: _Element, options: Extractor) -> None:
     "Iterate through an element child and rewire its descendants."
     new_child_elem.text = child.text
@@ -355,7 +393,8 @@ def handle_paragraphs(element: _Element, potential_tags: Set[str], options: Extr
 
     # children
     processed_element = Element(element.tag)
-    for child in element.iter("*"):
+    processed_element.text = _xml_compatible_text(element.text)
+    for child in list(element):
         if child.tag not in potential_tags and child.tag != "done":
             _log_event("unexpected in p", child.tag, child.text)
             continue
@@ -366,11 +405,11 @@ def handle_paragraphs(element: _Element, potential_tags: Set[str], options: Extr
             # todo: needing attention!
             if processed_child.tag == "p":
                 _log_event("extra in p", "p", processed_child.text)
-                if processed_element.text:
-                    processed_element.text += " " + (processed_child.text or "")
-                else:
-                    processed_element.text = processed_child.text
-                child.tag = "done"
+                _append_paragraph_text(
+                    processed_element,
+                    f"{processed_child.text or ''}{processed_child.tail or ''}",
+                )
+                _mark_subtree_done(child)
                 continue
             # handle formatting
             newsub = Element(child.tag)
@@ -379,7 +418,7 @@ def handle_paragraphs(element: _Element, potential_tags: Set[str], options: Extr
                 # check depth and clean
                 if len(processed_child) > 0:
                     for item in list(processed_child):  # children are lists
-                        if item.tag == "lb":
+                        if item.tag in {"graphic", "lb"}:
                             preserved_children.append(deepcopy(item))
                             item.tag = "done"
                             continue
@@ -424,7 +463,7 @@ def handle_paragraphs(element: _Element, potential_tags: Set[str], options: Extr
                 if image_elem is not None:
                     newsub = image_elem
             processed_element.append(newsub)
-        child.tag = "done"
+        _mark_subtree_done(child)
     # finish
     if len(processed_element) > 0:
         last_elem = processed_element[-1]

--- a/trafilatura/main_extractor.py
+++ b/trafilatura/main_extractor.py
@@ -414,13 +414,10 @@ def handle_paragraphs(element: _Element, potential_tags: Set[str], options: Extr
             # handle formatting
             newsub = Element(child.tag)
             if processed_child.tag in P_FORMATTING:
-                preserved_children = []
                 # check depth and clean
                 if len(processed_child) > 0:
                     for item in list(processed_child):  # children are lists
                         if item.tag in {"graphic", "lb"}:
-                            preserved_children.append(deepcopy(item))
-                            item.tag = "done"
                             continue
                         if text_chars_test(item.text) is True:
                             item.text = " " + item.text  # type: ignore[operator]
@@ -434,8 +431,10 @@ def handle_paragraphs(element: _Element, potential_tags: Set[str], options: Extr
                     # Preserve anchor ids (e.g., footnote links) so in-document jumps still work.
                     if child.get("id") is not None:
                         newsub.set("id", child.get("id", ""))
-                if preserved_children:
-                    for preserved in preserved_children:
+                if len(processed_child) > 0:
+                    for preserved in list(processed_child):
+                        if preserved.tag not in {"graphic", "lb"}:
+                            continue
                         newsub.append(preserved)
             # handle line breaks
             # elif processed_child.tag == 'lb':

--- a/trafilatura/settings.py
+++ b/trafilatura/settings.py
@@ -381,7 +381,6 @@ MANUALLY_CLEANED = [
     "label",
     "legend",
     "marquee",
-    "math",
     "menuitem",
     "nav",
     "noindex",

--- a/trafilatura/settings.py
+++ b/trafilatura/settings.py
@@ -6,14 +6,14 @@ Listing a series of settings that are applied module-wide.
 from configparser import ConfigParser
 from datetime import datetime
 from html import unescape
+import os
 from typing import Any, Dict, List, Optional, Set
 
-try:
-    from os import sched_getaffinity
+sched_getaffinity = getattr(os, "sched_getaffinity", None)
+if sched_getaffinity is not None:
     CPU_COUNT = len(sched_getaffinity(0))
-except ImportError:
-    from os import cpu_count
-    CPU_COUNT = cpu_count() or 1
+else:
+    CPU_COUNT = os.cpu_count() or 1
 
 from pathlib import Path
 

--- a/trafilatura/spider.py
+++ b/trafilatura/spider.py
@@ -7,7 +7,7 @@ import logging
 
 from configparser import ConfigParser
 from time import sleep
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Union
 from urllib.robotparser import RobotFileParser
 
 from courlan import (
@@ -50,7 +50,7 @@ class CrawlParameters:
         start: str,
         lang: Optional[str] = None,
         rules: Optional[RobotFileParser] = None,
-        prune_xpath: Optional[str] = None,
+        prune_xpath: Optional[Union[str, List[str]]] = None,
     ) -> None:
         self.start: str = start
         self.base: str = self._get_base_url(start)
@@ -60,7 +60,7 @@ class CrawlParameters:
         self.i: int = 0
         self.known_num: int = 0
         self.is_on: bool = True
-        self.prune_xpath: Optional[str] = prune_xpath
+        self.prune_xpath: Optional[Union[str, List[str]]] = prune_xpath
 
     def _get_base_url(self, start: str) -> str:
         "Set reference domain for the crawl."
@@ -205,11 +205,14 @@ def process_links(
         return
 
     if htmlstring and params.prune_xpath is not None:
-        if isinstance(params.prune_xpath, str):
-            params.prune_xpath = [params.prune_xpath]  # type: ignore[assignment]
+        prune_xpaths = (
+            [params.prune_xpath]
+            if isinstance(params.prune_xpath, str)
+            else params.prune_xpath
+        )
         tree = load_html(htmlstring)
         if tree is not None:
-            tree = prune_unwanted_nodes(tree, [XPath(x) for x in params.prune_xpath])
+            tree = prune_unwanted_nodes(tree, [XPath(x) for x in prune_xpaths])
             htmlstring = tostring(tree).decode()
 
     links, links_priority = [], []
@@ -251,7 +254,7 @@ def init_crawl(
     rules: Optional[RobotFileParser] = None,
     todo: Optional[List[str]] = None,
     known: Optional[List[str]] = None,
-    prune_xpath: Optional[str] = None,
+    prune_xpath: Optional[Union[str, List[str]]] = None,
 ) -> CrawlParameters:
     """Initialize crawl by setting variables, copying values to the
     URL store and retrieving the initial page if the crawl starts."""
@@ -312,7 +315,7 @@ def focused_crawler(
     lang: Optional[str] = None,
     config: ConfigParser = DEFAULT_CONFIG,
     rules: Optional[RobotFileParser] = None,
-    prune_xpath: Optional[str] = None,
+    prune_xpath: Optional[Union[str, List[str]]] = None,
 ) -> Tuple[List[str], List[str]]:
     """Basic crawler targeting pages of interest within a website.
 

--- a/trafilatura/utils.py
+++ b/trafilatura/utils.py
@@ -32,7 +32,7 @@ except ImportError:
     HAS_BROTLI = False
 
 try:
-    import zstandard
+    import zstandard  # type: ignore[import-not-found]
     HAS_ZSTD = True
 except ImportError:
     HAS_ZSTD = False


### PR DESCRIPTION
## Summary
- preserve inline extractor markup like `ref` and `hi` when processed paragraphs are inserted into table cells
- preserve leading spaces in inline formatting tails outside paragraphs so linked words do not collapse into following text
- add and update table-processing regressions covering the Paul Graham-style inline anchor case

## Root cause
Trafilatura's table-cell extraction path was discarding nested inline children when `define_newelem()` inserted a processed paragraph into a `<cell>`. That dropped linked words like `war` in Paul Graham's `The Brand Age`. Separately, `handle_formatting()` trimmed leading whitespace from inline tails, which could collapse `war on design` into `waron design`.

## Validation
- `.venv/bin/pytest -q tests/unit_tests.py -k 'test_table_processing or table_cell_inline_anchor_tail_is_preserved or list_item_anchor_tail_space_is_preserved or inline_anchor_paragraph_merge or link_ids_are_preserved'`
- `.venv/bin/pytest`
