### PR TITLE
Fix comment content leaking into main text when include_comments=False

### DIFF
--- a/trafilatura/core.py
+++ b/trafilatura/core.py
@@ -280,6 +280,10 @@ def bare_extraction(
             )
         else:
             commentsbody, temp_comments, len_comments = Element("body"), "", 0
+            # When comments are disabled, prune comment nodes from the tree
+            # to prevent them from leaking into the main text extraction.
+            # Previously this only ran in "precision" mode.
+            cleaned_tree = prune_unwanted_nodes(cleaned_tree, REMOVE_COMMENTS_XPATH)
         if options.focus == "precision":
             cleaned_tree = prune_unwanted_nodes(cleaned_tree, REMOVE_COMMENTS_XPATH)
 

--- a/trafilatura/xpaths.py
+++ b/trafilatura/xpaths.py
@@ -64,23 +64,23 @@ BODY_XPATH = [XPath(x) for x in (
 
 
 COMMENTS_XPATH = [XPath(x) for x in (
-    """.//*[self::div or self::list or self::section][contains(@id|@class, 'commentlist')
+    """.//*[self::details or self::div or self::list or self::section][contains(@id|@class, 'commentlist')
     or contains(@class, 'comment-page') or
     contains(@id|@class, 'comment-list') or
     contains(@class, 'comments-content') or contains(@class, 'post-comments')]""",
-    """.//*[self::div or self::section or self::list][starts-with(@id|@class, 'comments')
+    """.//*[self::details or self::div or self::section or self::list][starts-with(@id|@class, 'comments')
     or starts-with(@class, 'Comments') or
     starts-with(@id|@class, 'comment-') or
     contains(@class, 'article-comments')]""",
-    """.//*[self::div or self::section or self::list][starts-with(@id, 'comol') or
+    """.//*[self::details or self::div or self::section or self::list][starts-with(@id, 'comol') or
     starts-with(@id, 'disqus_thread') or starts-with(@id, 'dsq-comments')]""",
-    ".//*[self::div or self::section][starts-with(@id, 'social') or contains(@class, 'comment')]",
+    ".//*[self::details or self::div or self::section][starts-with(@id, 'social') or contains(@class, 'comment')]",
 )]
 # or contains(@class, 'Comments')
 
 
 REMOVE_COMMENTS_XPATH = [XPath(
-    """.//*[self::div or self::list or self::section][
+    """.//*[self::details or self::div or self::list or self::section][
     starts-with(translate(@id, "C","c"), 'comment') or
     starts-with(translate(@class, "C","c"), 'comment') or
     contains(@class, 'article-comments') or contains(@class, 'post-comments')
@@ -196,7 +196,7 @@ DISCARD_IMAGE_ELEMENTS = [XPath(
 
 
 COMMENTS_DISCARD_XPATH = [XPath(x) for x in (
-    './/*[self::div or self::section][starts-with(@id, "respond")]',
+    './/*[self::details or self::div or self::section][starts-with(@id, "respond")]',
     './/cite|.//quote',
     '''.//*[@class="comments-title" or contains(@class, "comments-title") or
     contains(@class, "nocomments") or starts-with(@id|@class, "reply-") or


### PR DESCRIPTION
Fixes #850.

Comment sections leak into extracted main text when `include_comments=False` (the default) unless `focus='precision'` is also set.

### Changes

**`core.py`:**
- Move `prune_unwanted_nodes()` for comment XPaths into the `else` branch (comments disabled) so comment nodes are always removed when `include_comments=False`, regardless of focus mode

**`xpaths.py`:**
- Add `self::details` to the 6 comment-related XPath expressions (`COMMENTS_XPATH` and `COMMENTS_DISCARD_XPATH`) so that `<details>` elements with comment-indicating class names are correctly identified as comment blocks

### Tests

- All existing tests pass (no regressions)
- mypy clean (same error count as master)

### Motivation

Sites like LWN.net wrap comment threads in `<details class="CommentBox">` elements. Without `self::details` in the XPath expressions, these are never identified as comments. And even when comments are identified, they are only pruned in precision mode — not when `include_comments=False` is set with the default focus.