### PR TITLE
fix: add tests to prevent metadata bugs

### DIFF
--- a/tests/json_metadata_tests.py
+++ b/tests/json_metadata_tests.py
@@ -8,6 +8,7 @@ import sys
 from lxml import html
 
 from trafilatura.metadata import Document, extract_meta_json, extract_metadata, normalize_authors
+from trafilatura.json_metadata import JSON_AUTHOR_1, JSON_AUTHOR_2, extract_json, extract_json_author, normalize_json, process_parent
 
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 
@@ -94,8 +95,8 @@ def test_json_extraction():
 }
 </script>
 </body></html>'''), metadata)
-    assert metadata is not None and metadata.title == 'Apple Spring Forward Event Live Blog'
-    assert metadata is not None and metadata.pagetype == 'liveblogposting'
+    assert metadata.title == 'Apple Spring Forward Event Live Blog'
+    assert metadata.pagetype == 'liveblogposting'
 
     ### Test for potential errors
     metadata = Document()
@@ -135,8 +136,8 @@ def test_json_extraction():
 </script>
 </body></html>'''), metadata)
 
-    assert metadata is not None and metadata.title == 'Apple Spring Forward Event Live Blog'
-    assert metadata is not None and metadata.pagetype == 'liveblogposting'
+    assert metadata.title == 'Apple Spring Forward Event Live Blog'
+    assert metadata.pagetype == 'liveblogposting'
 
     ### Test for potential errors - Missing content on live blog
     metadata = Document()
@@ -160,8 +161,8 @@ def test_json_extraction():
     </script>
     </body></html>'''), metadata)
 
-    assert metadata is not None and metadata.title == 'Apple Spring Forward Event Live Blog'
-    assert metadata is not None and metadata.pagetype == 'liveblogposting'
+    assert metadata.title == 'Apple Spring Forward Event Live Blog'
+    assert metadata.pagetype == 'liveblogposting'
 
     metadata = Document()
     metadata = extract_meta_json(html.fromstring('''
@@ -195,8 +196,8 @@ def test_json_extraction():
     </script>
 </script>
 </body></html>'''), metadata)
-    assert metadata is not None and metadata.author == 'Douglas Noel Adams'
-    assert metadata is not None and metadata.pagetype == 'socialmediaposting'
+    assert metadata.author == 'Douglas Noel Adams'
+    assert metadata.pagetype == 'socialmediaposting'
 
     metadata = Document()
     metadata = extract_meta_json(html.fromstring('''
@@ -224,8 +225,8 @@ def test_json_extraction():
     </script>
 </script>
 </body></html>'''), metadata)
-    assert metadata is not None and len(metadata.categories) == 0
-    assert metadata is not None and metadata.pagetype == 'article'
+    assert len(metadata.categories) == 0
+    assert metadata.pagetype == 'article'
 
     metadata = Document()
     metadata = extract_meta_json(html.fromstring('''
@@ -335,7 +336,7 @@ def test_json_extraction():
     </script>
 </script>
 </body></html>'''), metadata)
-    assert metadata is not None and metadata.title == "Mickelson comments hurt new league: Norman" and metadata.sitename == "7NEWS" and metadata.author == "Digital Staff" and "Golf" in metadata.categories and metadata.pagetype == 'newsarticle'
+    assert metadata.title == "Mickelson comments hurt new league: Norman" and metadata.sitename == "7NEWS" and metadata.author == "Digital Staff" and "Golf" in metadata.categories and metadata.pagetype == 'newsarticle'
 
     metadata = Document()
     metadata = extract_meta_json(html.fromstring('''
@@ -376,7 +377,7 @@ def test_json_extraction():
     </script>
 </script>
 </body></html>'''), metadata)
-    assert metadata is not None and metadata.title == "Australians stuck in Shanghai's COVID lockdown beg consular officials to help them flee" and metadata.author == "Bill Birtles" and metadata.sitename == "ABC News" and metadata.pagetype == 'newsarticle'
+    assert metadata.title == "Australians stuck in Shanghai's COVID lockdown beg consular officials to help them flee" and metadata.author == "Bill Birtles" and metadata.sitename == "ABC News" and metadata.pagetype == 'newsarticle'
 
     metadata = Document()
     metadata = extract_meta_json(html.fromstring('''
@@ -481,7 +482,7 @@ def test_json_extraction():
     </script>
 </script>
 </body></html>'''), metadata)
-    assert metadata is not None and metadata.title == "New York City Enters Higher Coronavirus Risk Level as Case Numbers Rise" and metadata.author == "Sharon Otterman; Emma G Fitzsimmons" and metadata.sitename == "The New York Times" and metadata.pagetype == 'newsarticle'
+    assert metadata.title == "New York City Enters Higher Coronavirus Risk Level as Case Numbers Rise" and metadata.author == "Sharon Otterman; Emma G Fitzsimmons" and metadata.sitename == "The New York Times" and metadata.pagetype == 'newsarticle'
 
     metadata = Document()
     metadata = extract_meta_json(html.fromstring('''
@@ -523,7 +524,7 @@ def test_json_extraction():
     </script>
 </script>
 </body></html>'''), metadata)
-    assert metadata is not None and metadata.title == "Decreto permite que consumidor cancele serviços de empresas via WhatsApp" and metadata.author == "Caio Mello" and metadata.sitename == "UOL"
+    assert metadata.title == "Decreto permite que consumidor cancele serviços de empresas via WhatsApp" and metadata.author == "Caio Mello" and metadata.sitename == "UOL"
 
     metadata = Document()
     metadata = extract_meta_json(html.fromstring('''
@@ -571,7 +572,7 @@ def test_json_extraction():
     </script>
 </script>
 </body></html>'''), metadata)
-    assert metadata is not None and metadata.title == "12 words and phrases you need to survive in Hamburg" and metadata.author == "Alexander Johnstone" and metadata.sitename == "The Local" and metadata.pagetype == 'newsarticle'
+    assert metadata.title == "12 words and phrases you need to survive in Hamburg" and metadata.author == "Alexander Johnstone" and metadata.sitename == "The Local" and metadata.pagetype == 'newsarticle'
 
     metadata = Document()
     metadata = extract_meta_json(html.fromstring('''
@@ -621,7 +622,7 @@ def test_json_extraction():
         }
 </script>
 </body></html>'''), metadata)
-    assert metadata is not None and metadata.author is None and metadata.sitename == "Andreessen Horowitz" and metadata.pagetype == 'website'
+    assert metadata.author is None and metadata.sitename == "Andreessen Horowitz" and metadata.pagetype == 'website'
 
     metadata = Document()
     metadata = extract_meta_json(html.fromstring('''
@@ -637,7 +638,7 @@ def test_json_extraction():
 </script>
 </body></html>'''), metadata)
 
-    assert metadata is not None and metadata.author is None and metadata.sitename is None and metadata.pagetype is None
+    assert metadata.author is None and metadata.sitename is None and metadata.pagetype is None
 
     metadata = Document()
     metadata = extract_meta_json(html.fromstring('''
@@ -666,7 +667,7 @@ def test_json_extraction():
     </script>
     </body></html>'''), metadata)
 
-    assert metadata is not None and metadata.author is None and metadata.sitename is None and metadata.pagetype == 'liveblogposting'
+    assert metadata.author is None and metadata.sitename is None and metadata.pagetype == 'liveblogposting'
 
     metadata = Document()
     metadata = extract_meta_json(html.fromstring('''
@@ -694,7 +695,7 @@ def test_json_extraction():
 }
 </script>
 </body></html>'''), metadata)
-    assert metadata is not None and metadata.title == 'Apple Spring Forward Event Live Blog' and metadata.pagetype == 'liveblogposting'
+    assert metadata.title == 'Apple Spring Forward Event Live Blog' and metadata.pagetype == 'liveblogposting'
 
     metadata = Document()
     metadata = extract_meta_json(html.fromstring(r'''
@@ -745,7 +746,7 @@ def test_json_extraction():
 </script>
 </body></html>'''), metadata)
 
-    assert metadata is not None and metadata.title == "EastEnders' June Brown leaves soap 'for good'" and metadata.sitename == "BBC News" and metadata.pagetype == 'reportagenewsarticle'
+    assert metadata.title == "EastEnders' June Brown leaves soap 'for good'" and metadata.sitename == "BBC News" and metadata.pagetype == 'reportagenewsarticle'
 
     metadata = Document()
     metadata.sitename = "https://bbcnews.com"
@@ -769,7 +770,7 @@ def test_json_extraction():
     </script>
     </body></html>'''), metadata)
 
-    assert metadata is not None and metadata.sitename == "BBC News" and metadata.pagetype == 'reportagenewsarticle'
+    assert metadata.sitename == "BBC News" and metadata.pagetype == 'reportagenewsarticle'
 
     metadata = Document()
     metadata = extract_meta_json(html.fromstring('''
@@ -801,7 +802,7 @@ def test_json_extraction():
     </script>
     </body></html>'''), metadata)
 
-    assert metadata is not None and metadata.author == "John Doe" and metadata.title == "How to Tie a Reef Knot" and metadata.pagetype == 'article'
+    assert metadata.author == "John Doe" and metadata.title == "How to Tie a Reef Knot" and metadata.pagetype == 'article'
 
     metadata = Document()
     metadata = extract_meta_json(html.fromstring('''
@@ -820,7 +821,7 @@ def test_json_extraction():
         </script>
     </script>
     </body></html>'''), metadata)
-    assert metadata is not None and metadata.author == "Bill Birtles; John Smith" and metadata.pagetype == 'newsarticle'
+    assert metadata.author == "Bill Birtles; John Smith" and metadata.pagetype == 'newsarticle'
 
     metadata = Document()
     metadata = extract_meta_json(html.fromstring('''
@@ -838,7 +839,7 @@ def test_json_extraction():
         </script>
     </body></html>'''), metadata)
 
-    assert metadata is not None and metadata.title is None and metadata.sitename is None and metadata.pagetype is None
+    assert metadata.title is None and metadata.sitename is None and metadata.pagetype is None
 
     metadata = Document()
     metadata = extract_meta_json(html.fromstring('''
@@ -894,7 +895,7 @@ def test_json_extraction():
         </script>
     </body></html>'''), metadata)
 
-    assert metadata is not None and metadata.title == "Find perfection in these places where land meets water." and metadata.sitename == "National Geographic" and metadata.author == "Kimberley Lovato" and metadata.pagetype == 'article'
+    assert metadata.title == "Find perfection in these places where land meets water." and metadata.sitename == "National Geographic" and metadata.author == "Kimberley Lovato" and metadata.pagetype == 'article'
 
     # tests that "@type": [] in the JSON doesn't cause an exception
 
@@ -950,6 +951,10 @@ def test_json_extraction():
 def test_normalize_authors():
     "Test if author names are normalized correctly."
     assert normalize_authors(None, "John Doe") == "John Doe"
+    assert normalize_authors(None, "abc") == "Abc"
+    assert normalize_authors(None, "Steve Steve 123") == "Steve Steve"
+    assert normalize_authors(None, "By Steve Steve") == "Steve Steve"
+    assert normalize_authors(None, "123") is None  # no usable name -> returns current
     assert normalize_authors("Alice; Bob", "John Doe") == "Alice; Bob; John Doe"
     assert normalize_authors("Alice; Bob", "john.doe@example.com") == "Alice; Bob"
     assert normalize_authors(None, "\\u00e9tienne") == "Étienne"
@@ -965,8 +970,71 @@ def test_normalize_authors():
     assert normalize_authors(None, "John Doe of John Doe") == "John Doe"
     assert normalize_authors(None, "John Doe — John Doe") == "John Doe"
     assert normalize_authors(None, 'John "The King" Doe') == "John  Doe"
+    # dedup keeps the fullest form regardless of order
+    assert normalize_authors("Smith", "John Smith") == "John Smith"
+    assert normalize_authors("John Smith", "Smith") == "John Smith"
+
+
+def test_normalize_json():
+    "Test JSON string normalization (escapes, surrogates, HTML)."
+    assert normalize_json('Test \\nthis') == 'Test this'
+    assert normalize_json('\\uD800\\uDC00Hello\\uDBFF\\uDFFF') == 'Hello'
+    assert normalize_json('Test 【ABC】') == 'Test 【ABC】'
+    assert normalize_json("Seán Federico O'Murchú") == "Seán Federico O'Murchú"
+
+
+def test_extract_json_shapes():
+    "JSON-LD container shapes and process_parent field-extraction branches."
+    # @graph wrapper
+    schema = [{"@context": "https://schema.org", "@graph": [{"@type": "Article", "author": {"name": "Jane Doe"}}]}]
+    assert extract_json(schema, Document()).author == "Jane Doe"
+    # list-valued articleSection
+    assert process_parent([{"@type": "Article", "articleSection": ["News", "Politics"]}], Document()).categories == ["News", "Politics"]
+    # a Person with a plain-string name yields the author
+    assert process_parent([{"@type": "Person", "name": "Jane Doe"}], Document()).author == "Jane Doe"
+    # a longer organization name supersedes a shorter sitename
+    assert process_parent([{"@type": "Organization", "name": "AB"}, {"@type": "Organization", "name": "ABCD Corp"}], Document()).sitename == "ABCD Corp"
+
+
+def test_json_metadata_robustness():
+    "Malformed/edge JSON-LD shapes must not raise and should extract where possible."
+    # "names" key leaves the first author regex group empty
+    assert extract_json_author('{"author":{"names":"Jane Doe"}}', JSON_AUTHOR_1) == "Jane Doe"
+    assert extract_json_author('{"author":{"name":"Jane Doe"}}', JSON_AUTHOR_1) == "Jane Doe"
+    assert extract_json_author('{"Person":{"names":"Jane Doe"}}', JSON_AUTHOR_2) == "Jane Doe"
+    # a single-word match (no space) is skipped
+    assert extract_json_author('{"author":{"name":"Cher"}}', JSON_AUTHOR_1) is None
+    # publisher as a bare string
+    assert process_parent([{"publisher": "the name of co"}], Document()).sitename is None
+    assert process_parent([{"publisher": {"name": "Acme"}}], Document()).sitename == "Acme"
+    # Person.name as a list must not raise
+    assert process_parent([{"@type": "Person", "name": ["Jane", "Doe"]}], Document()).author is None
+    # article author as a list of plain strings must be extracted, not dropped
+    assert process_parent([{"@type": "Article", "author": ["John Doe", "Jane Smith"]}], Document()).author == "John Doe; Jane Smith"
+    # malformed JSON-LD (non-dict items) is swallowed by extract_metadata, not raised
+    assert extract_metadata('<html><body><script type="application/ld+json">[123]</script></body></html>') is not None
+
+
+def test_extract_json_processes_list_once():
+    "A flat list of @context objects is processed once, not once per item."
+    import trafilatura.json_metadata as jm
+    schema = [
+        {"@context": "https://schema.org", "@type": "NewsArticle", "headline": "A"},
+        {"@context": "https://schema.org", "@type": "NewsArticle", "headline": "B"},
+    ]
+    orig, count = jm.process_parent, []
+    jm.process_parent = lambda p, m: count.append(1) or orig(p, m)
+    try:
+        extract_json(schema, Document())
+    finally:
+        jm.process_parent = orig
+    assert len(count) == 1
 
 
 if __name__ == '__main__':
     test_json_extraction()
     test_normalize_authors()
+    test_normalize_json()
+    test_extract_json_shapes()
+    test_json_metadata_robustness()
+    test_extract_json_processes_list_once()

--- a/tests/metadata_tests.py
+++ b/tests/metadata_tests.py
@@ -9,8 +9,7 @@ import sys
 from lxml import html
 from lxml.etree import XPath
 
-from trafilatura.json_metadata import normalize_authors, normalize_json
-from trafilatura.metadata import check_authors, extract_metadata, extract_metainfo, extract_url, normalize_tags
+from trafilatura.metadata import check_authors, extract_metadata, extract_metainfo, extract_title, extract_url, normalize_tags
 
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 
@@ -43,168 +42,103 @@ def test_titles():
     assert metadata.title == "My Title"  # TODO: and metadata.sitename == "My Website"
 
 
-def test_authors():
-    '''Test the extraction of author names'''
-    # normalization
-    assert normalize_authors(None, 'abc') == 'Abc'
-    assert normalize_authors(None, 'Steve Steve 123') == 'Steve Steve'
-    assert normalize_authors(None, 'By Steve Steve') == 'Steve Steve'
-    assert normalize_json('Test \\nthis') == 'Test this'
-    assert normalize_json('\\uD800\\uDC00Hello\\uDBFF\\uDFFF') == 'Hello'
-    assert normalize_json('Test \u3010ABC\u3011') == 'Test 【ABC】'
-    assert normalize_json("Seán Federico O'Murchú") == "Seán Federico O'Murchú"
-
-    # blacklist
+def test_author_blacklist():
+    '''Filtering of author names against a blacklist'''
     metadata = extract_metadata('<html><head><meta itemprop="author" content="Jenny Smith"/></head><body></body></html>', author_blacklist={'Jenny Smith'})
     assert metadata.author is None
-
-    # extraction
-    begin, end = '<html><head>', '</head><body></body></html>'
-    htmldocs = [
-        f'{begin}<meta itemprop="author" content="Jenny Smith"/>{end}',
-        f'{begin}<meta itemprop="author" content="Jenny Smith"/><meta itemprop="author" content="John Smith"/>{end}',
-        f'{begin}<meta itemprop="author" content="Jenny Smith und John Smith"/>{end}',
-        f'{begin}<meta name="author" content="Jenny Smith"/><meta name="author" content="John Smith"/>{end}',
-        f'{begin}<meta name="author" content="Jenny Smith and John Smith"/>{end}',
-        f'{begin}<meta name="author" content="Jenny Smith"/>{end}',
-        f'{begin}<meta name="author" content="Hank O&#39;Hop"/>{end}',
-        f'{begin}<meta name="author" content="Jenny Smith ❤️"/>{end}',
-        f'{begin}<meta name="citation_author" content="Jenny Smith and John Smith"/>{end}',
-        f'{begin}<meta property="author" content="Jenny Smith"/><meta property="author" content="John Smith"/>{end}',
-        f'{begin}<meta itemprop="author" content="Jenny Smith and John Smith"/>{end}',
-        f'{begin}<meta name="article:author" content="Jenny Smith"/>{end}',
-    ]
-    expected_authors = [
-        'Jenny Smith',
-        'Jenny Smith; John Smith',
-        'Jenny Smith; John Smith',
-        'Jenny Smith; John Smith',
-        'Jenny Smith; John Smith',
-        'Jenny Smith',
-        'Hank O\'Hop',
-        'Jenny Smith',
-        'Jenny Smith; John Smith',
-        'Jenny Smith; John Smith',
-        'Jenny Smith; John Smith',
-        'Jenny Smith',
-    ]
-
-
-    for doc, expected_author in zip(htmldocs, expected_authors):
-        metadata = extract_metadata(doc)
-        assert metadata.author == expected_author
-
-    begin, end = '<html><body>', '</body></html>'
-    htmldocs = [
-        f'{begin}<a href="" rel="author">Jenny Smith</a>{end}',
-        f'{begin}<a href="" rel="author">Jenny "The Author" Smith</a>{end}',
-        f'{begin}<span class="author">Jenny Smith</span>f{end}',
-        f'{begin}<h4 class="author">Jenny Smith</h4>f{end}',
-        f'{begin}<h4 class="author">Jenny Smith — Trafilatura</h4>f{end}',
-        f'{begin}<span class="wrapper--detail__writer">Jenny Smith</span>f{end}',
-        f'{begin}<span id="author-name">Jenny Smith</span>f{end}',
-        f'{begin}<figure data-component="Figure"><div class="author">Jenny Smith</div></figure>f{end}',
-        f'{begin}<div class="sidebar"><div class="author">Jenny Smith</div></figure>f{end}',
-        f'{begin}<div class="quote"><p>My quote here</p><p class="quote-author"><span>—</span> Jenny Smith</p></div>f{end}',
-        f'{begin}<span class="author">Jenny Smith and John Smith</span>f{end}',
-        f'{begin}<a class="author">Jenny Smith</a>f{end}',
-        f'{begin}<a class="author">Jenny Smith <div class="title">Editor</div></a>f{end}',
-        f'{begin}<a class="author">Jenny Smith from Trafilatura</a>f{end}',
-        f'{begin}<meta itemprop="author" content="Fake Author"/><a class="author">Jenny Smith from Trafilatura</a>f{end}',
-        f'{begin}<a class="username">Jenny Smith</a>f{end}',
-        f'{begin}<div class="submitted-by"><a>Jenny Smith</a></div>f{end}',
-        f'{begin}<div class="byline-content"><div class="byline"><a>Jenny Smith</a></div><time>July 12, 2021 08:05</time></div>f{end}',
-        f'{begin}<h3 itemprop="author">Jenny Smith</h3>f{end}',
-        f'{begin}<div class="article-meta article-meta-byline article-meta-with-photo article-meta-author-and-reviewer" itemprop="author" itemscope="" itemtype="http://schema.org/Person"><span class="article-meta-photo-wrap"><img src="" alt="Jenny Smith" itemprop="image" class="article-meta-photo"></span><span class="article-meta-contents"><span class="article-meta-author">By <a href="" itemprop="url"><span itemprop="name">Jenny Smith</span></a></span><span class="article-meta-date">May 18 2022</span><span class="article-meta-reviewer">Reviewed by <a href="">Robert Smith</a></span></span></div>f{end}',
-        f'{begin}<div data-component="Byline">Jenny Smith</div>f{end}',
-        f'{begin}<span id="author">Jenny Smith</span>f{end}',
-        f'{begin}<span id="author">Jenny Smith – The Moon</span>f{end}',
-        f'{begin}<span id="author">Jenny_Smith</span>f{end}',
-    ]
-    expected_authors = [
-        'Jenny Smith',
-        'Jenny Smith',
-        'Jenny Smith',
-        'Jenny Smith',
-        'Jenny Smith',
-        'Jenny Smith',
-        'Jenny Smith',
-        None,
-        None,
-        None,
-        'Jenny Smith; John Smith',
-        'Jenny Smith',
-        'Jenny Smith',
-        'Jenny Smith',
-        'Jenny Smith',
-        'Jenny Smith',
-        'Jenny Smith',
-        'Jenny Smith',
-        'Jenny Smith',
-        'Jenny Smith',
-        'Jenny Smith',
-        'Jenny Smith',
-        'Jenny Smith',
-        'Jenny Smith',
-    ]
-
-    for doc, expected_author in zip(htmldocs, expected_authors):
-        metadata = extract_metadata(doc)
-        assert metadata.author == expected_author
-
-    htmldocs = [
-        f'{begin}<span itemprop="author name">Shannon Deery, Mitch Clarke, Susie O’Brien, Laura Placella, Kara Irving, Jordy Atkinson, Suzan Delibasic</span>f{end}',
-        f'{begin}<address class="author">Jenny Smith</address>f{end}',
-        f'{begin}<author>Jenny Smith</author>f{end}',
-        '<html><head><meta data-rh="true" property="og:author" content="By &lt;a href=&quot;/profiles/amir-vera&quot;&gt;Amir Vera&lt;/a&gt;, Seán Federico O&#x27;Murchú, &lt;a href=&quot;/profiles/tara-subramaniam&quot;&gt;Tara Subramaniam&lt;/a&gt; and Adam Renton, CNN"/></head><body>f{end}',
-        f'{begin}<div class="author"><span class="profile__name"> Jenny Smith </span> <a href="https://twitter.com/jenny_smith" class="profile__social" target="_blank"> @jenny_smith </a> <span class="profile__extra lg:hidden"> 11:57AM </span> </div>f{end}',
-        f'{begin}<p class="author-section byline-plain">By <a class="author" rel="nofollow">Jenny Smith For Daily Mail Australia</a></p>f{end}',
-        f'{begin}<div class="o-Attribution__a-Author"><span class="o-Attribution__a-Author--Label">By:</span><span class="o-Attribution__a-Author--Prefix"><span class="o-Attribution__a-Name"><a href="//web.archive.org/web/20210707074846/https://www.discovery.com/profiles/ian-shive">Ian Shive</a></span></span></div>f{end}',
-        f'{begin}<div class="ArticlePage-authors"><div class="ArticlePage-authorName" itemprop="name"><span class="ArticlePage-authorBy">By&nbsp;</span><a aria-label="Ben Coxworth" href="https://newatlas.com/author/ben-coxworth/"><span>Ben Coxworth</span></a></div></div>f{end}',
-        f'{begin}<div><strong><a class="d1dba0c3091a3c30ebd6" data-testid="AuthorURL" href="/by/p535y1">AUTHOR NAME</a></strong></div>f{end}'
-    ]
-    expected_authors = [
-        'Shannon Deery; Mitch Clarke; Susie O’Brien; Laura Placella; Kara Irving; Jordy Atkinson; Suzan Delibasic',
-        'Jenny Smith',
-        'Jenny Smith',
-        "Amir Vera; Seán Federico O'Murchú; Tara Subramaniam; Adam Renton; CNN",
-        'Jenny Smith',
-        'Jenny Smith',
-        'Ian Shive',
-        'Ben Coxworth',
-        'AUTHOR NAME'
-    ]
-
-    for doc, expected_author in zip(htmldocs, expected_authors):
-        metadata = extract_metadata(doc)
-        assert metadata.author == expected_author
-
-    # check authors string
+    # a JSON-LD author is filtered (first check, before the markup fallback)
+    metadata = extract_metadata('<html><body><script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","author":{"name":"Jane Doe"}}</script></body></html>', author_blacklist={'Jane Doe'})
+    assert metadata.author is None
+    # a markup-extracted author is filtered on the recheck pass
+    metadata = extract_metadata('<html><body><a class="author">Jane Doe</a></body></html>', author_blacklist={'Jane Doe'})
+    assert metadata.author is None
+    # a single-word meta author is discarded
+    assert extract_metadata('<html><head><meta name="author" content="Cher"/></head><body/></html>').author is None
     blacklist = {"A", "b"}
     assert check_authors("a; B; c; d", blacklist) == "c; d"
     assert check_authors("a;B;c;d", blacklist) == "c; d"
 
 
+def test_author_from_meta():
+    '''Author extraction from <head> meta tags'''
+    begin, end = '<html><head>', '</head><body></body></html>'
+    cases = [
+        (f'{begin}<meta itemprop="author" content="Jenny Smith"/>{end}', 'Jenny Smith'),
+        (f'{begin}<meta itemprop="author" content="Jenny Smith"/><meta itemprop="author" content="John Smith"/>{end}', 'Jenny Smith; John Smith'),
+        (f'{begin}<meta itemprop="author" content="Jenny Smith und John Smith"/>{end}', 'Jenny Smith; John Smith'),
+        (f'{begin}<meta name="author" content="Jenny Smith"/><meta name="author" content="John Smith"/>{end}', 'Jenny Smith; John Smith'),
+        (f'{begin}<meta name="author" content="Jenny Smith and John Smith"/>{end}', 'Jenny Smith; John Smith'),
+        (f'{begin}<meta name="author" content="Jenny Smith"/>{end}', 'Jenny Smith'),
+        (f'{begin}<meta name="author" content="Hank O&#39;Hop"/>{end}', "Hank O'Hop"),
+        (f'{begin}<meta name="author" content="Jenny Smith ❤️"/>{end}', 'Jenny Smith'),
+        (f'{begin}<meta name="citation_author" content="Jenny Smith and John Smith"/>{end}', 'Jenny Smith; John Smith'),
+        (f'{begin}<meta property="author" content="Jenny Smith"/><meta property="author" content="John Smith"/>{end}', 'Jenny Smith; John Smith'),
+        (f'{begin}<meta itemprop="author" content="Jenny Smith and John Smith"/>{end}', 'Jenny Smith; John Smith'),
+        (f'{begin}<meta name="article:author" content="Jenny Smith"/>{end}', 'Jenny Smith'),
+    ]
+    for doc, expected in cases:
+        assert extract_metadata(doc).author == expected
+
+
+def test_author_from_markup():
+    '''Author extraction from body markup'''
+    begin, end = '<html><body>', '</body></html>'
+    cases = [
+        (f'{begin}<a href="" rel="author">Jenny Smith</a>{end}', 'Jenny Smith'),
+        (f'{begin}<a href="" rel="author">Jenny "The Author" Smith</a>{end}', 'Jenny Smith'),
+        (f'{begin}<span class="author">Jenny Smith</span>{end}', 'Jenny Smith'),
+        (f'{begin}<h4 class="author">Jenny Smith</h4>{end}', 'Jenny Smith'),
+        (f'{begin}<h4 class="author">Jenny Smith — Trafilatura</h4>{end}', 'Jenny Smith'),
+        (f'{begin}<span class="wrapper--detail__writer">Jenny Smith</span>{end}', 'Jenny Smith'),
+        (f'{begin}<span id="author-name">Jenny Smith</span>{end}', 'Jenny Smith'),
+        (f'{begin}<figure data-component="Figure"><div class="author">Jenny Smith</div></figure>{end}', None),
+        (f'{begin}<div class="sidebar"><div class="author">Jenny Smith</div></figure>{end}', None),
+        (f'{begin}<div class="quote"><p>My quote here</p><p class="quote-author"><span>—</span> Jenny Smith</p></div>{end}', None),
+        (f'{begin}<span class="author">Jenny Smith and John Smith</span>{end}', 'Jenny Smith; John Smith'),
+        (f'{begin}<a class="author">Jenny Smith</a>{end}', 'Jenny Smith'),
+        (f'{begin}<a class="author">Jenny Smith <div class="title">Editor</div></a>{end}', 'Jenny Smith'),
+        (f'{begin}<a class="author">Jenny Smith from Trafilatura</a>{end}', 'Jenny Smith'),
+        (f'{begin}<meta itemprop="author" content="Fake Author"/><a class="author">Jenny Smith from Trafilatura</a>{end}', 'Jenny Smith'),
+        (f'{begin}<a class="username">Jenny Smith</a>{end}', 'Jenny Smith'),
+        (f'{begin}<div class="submitted-by"><a>Jenny Smith</a></div>{end}', 'Jenny Smith'),
+        (f'{begin}<div class="byline-content"><div class="byline"><a>Jenny Smith</a></div><time>July 12, 2021 08:05</time></div>{end}', 'Jenny Smith'),
+        (f'{begin}<h3 itemprop="author">Jenny Smith</h3>{end}', 'Jenny Smith'),
+        (f'{begin}<div class="article-meta article-meta-byline article-meta-with-photo article-meta-author-and-reviewer" itemprop="author" itemscope="" itemtype="http://schema.org/Person"><span class="article-meta-photo-wrap"><img src="" alt="Jenny Smith" itemprop="image" class="article-meta-photo"></span><span class="article-meta-contents"><span class="article-meta-author">By <a href="" itemprop="url"><span itemprop="name">Jenny Smith</span></a></span><span class="article-meta-date">May 18 2022</span><span class="article-meta-reviewer">Reviewed by <a href="">Robert Smith</a></span></span></div>{end}', 'Jenny Smith'),
+        (f'{begin}<div data-component="Byline">Jenny Smith</div>{end}', 'Jenny Smith'),
+        (f'{begin}<span id="author">Jenny Smith</span>{end}', 'Jenny Smith'),
+        (f'{begin}<span id="author">Jenny Smith – The Moon</span>{end}', 'Jenny Smith'),
+        (f'{begin}<span id="author">Jenny_Smith</span>{end}', 'Jenny Smith'),
+        (f'{begin}<span itemprop="author name">Shannon Deery, Mitch Clarke, Susie O’Brien, Laura Placella, Kara Irving, Jordy Atkinson, Suzan Delibasic</span>{end}', 'Shannon Deery; Mitch Clarke; Susie O’Brien; Laura Placella; Kara Irving; Jordy Atkinson; Suzan Delibasic'),
+        (f'{begin}<address class="author">Jenny Smith</address>{end}', 'Jenny Smith'),
+        (f'{begin}<author>Jenny Smith</author>{end}', 'Jenny Smith'),
+        (f'<html><head><meta data-rh="true" property="og:author" content="By &lt;a href=&quot;/profiles/amir-vera&quot;&gt;Amir Vera&lt;/a&gt;, Seán Federico O&#x27;Murchú, &lt;a href=&quot;/profiles/tara-subramaniam&quot;&gt;Tara Subramaniam&lt;/a&gt; and Adam Renton, CNN"/></head><body>{end}', "Amir Vera; Seán Federico O'Murchú; Tara Subramaniam; Adam Renton; CNN"),
+        (f'{begin}<div class="author"><span class="profile__name"> Jenny Smith </span> <a href="https://twitter.com/jenny_smith" class="profile__social" target="_blank"> @jenny_smith </a> <span class="profile__extra lg:hidden"> 11:57AM </span> </div>{end}', 'Jenny Smith'),
+        (f'{begin}<p class="author-section byline-plain">By <a class="author" rel="nofollow">Jenny Smith For Daily Mail Australia</a></p>{end}', 'Jenny Smith'),
+        (f'{begin}<div class="o-Attribution__a-Author"><span class="o-Attribution__a-Author--Label">By:</span><span class="o-Attribution__a-Author--Prefix"><span class="o-Attribution__a-Name"><a href="//web.archive.org/web/20210707074846/https://www.discovery.com/profiles/ian-shive">Ian Shive</a></span></span></div>{end}', 'Ian Shive'),
+        (f'{begin}<div class="ArticlePage-authors"><div class="ArticlePage-authorName" itemprop="name"><span class="ArticlePage-authorBy">By&nbsp;</span><a aria-label="Ben Coxworth" href="https://newatlas.com/author/ben-coxworth/"><span>Ben Coxworth</span></a></div></div>{end}', 'Ben Coxworth'),
+        (f'{begin}<div><strong><a class="d1dba0c3091a3c30ebd6" data-testid="AuthorURL" href="/by/p535y1">AUTHOR NAME</a></strong></div>{end}', 'AUTHOR NAME'),
+    ]
+    for doc, expected in cases:
+        assert extract_metadata(doc).author == expected
+
+
 def test_url():
     '''Test URL extraction'''
-    htmldocs = [
-        '<html><head><meta property="og:url" content="https://example.org"/></head><body></body></html>',
-        '<html><head><link rel="canonical" href="https://example.org"/></head><body></body></html>',
-        '<html><head><meta name="twitter:url" content="https://example.org"/></head><body></body></html>',
-        '<html><head><link rel="alternate" hreflang="x-default" href="https://example.org"/></head><body></body></html>',
-        '<html><head><link rel="canonical" href="/article/medical-record"/></head><body></body></html>',
-        '<html><head><base href="https://example.org" target="_blank"/></head><body></body></html>',
+    expected = 'https://example.org'
+    cases = [
+        ('<html><head><meta property="og:url" content="https://example.org"/></head><body></body></html>', None),
+        ('<html><head><link rel="canonical" href="https://example.org"/></head><body></body></html>', None),
+        ('<html><head><meta name="twitter:url" content="https://example.org"/></head><body></body></html>', None),
+        ('<html><head><link rel="alternate" hreflang="x-default" href="https://example.org"/></head><body></body></html>', None),
+        ('<html><head><link rel="canonical" href="/article/medical-record"/></head><body></body></html>', "https://example.org"),
+        ('<html><head><base href="https://example.org" target="_blank"/></head><body></body></html>', None),
     ]
-    default_urls = [None, None, None, None, "https://example.org", None]
-    expected_url = 'https://example.org'
+    for doc, default_url in cases:
+        assert extract_metadata(doc, default_url).url == expected
 
-    for doc, default_url in zip(htmldocs, default_urls):
-        metadata = extract_metadata(doc, default_url)
-        assert metadata.url == expected_url
-
-    # test on partial URLs
-    url = extract_url(html.fromstring('<html><head><link rel="canonical" href="/article/medical-record"/><meta name="twitter:url" content="https://example.org"/></head><body></body></html>'))
-    assert url == 'https://example.org/article/medical-record'
+    # relative canonical joined via a twitter:url or og:url base
+    assert extract_url(html.fromstring('<html><head><link rel="canonical" href="/article/medical-record"/><meta name="twitter:url" content="https://example.org"/></head><body></body></html>')) == 'https://example.org/article/medical-record'
+    assert extract_url(html.fromstring('<html><head><link rel="canonical" href="/p"/><meta property="og:url" content="https://example.org"/></head><body></body></html>')) == 'https://example.org/p'
 
 
 def test_description():
@@ -218,12 +152,9 @@ def test_description():
 def test_dates():
     '''Simple tests for date extraction (most of the tests are carried out externally for htmldate module)'''
     tests = [
-        ('<html><head><meta property="og:published_time" content="2017-09-01"/></head><body></body></html>',
-        '2017-09-01', False),
-        ('<html><head><meta property="og:url" content="https://example.org/2017/09/01/content.html"/></head><body></body></html>',
-        '2017-09-01', False),
-        ('<html><head><meta property="og:url" content="https://example.org/2017/09/01/content.html"/></head><body></body></html>',
-        '2017-09-01', False),
+        ('<html><head><meta property="og:published_time" content="2017-09-01"/></head><body></body></html>', '2017-09-01', False),
+        ('<html><head><meta property="og:url" content="https://example.org/2017/09/01/content.html"/></head><body></body></html>', '2017-09-01', False),
+        ('<html><head><meta property="og:url" content="https://example.org/2017/09/01/content.html"/></head><body></body></html>', '2017-09-01', False),
         ('<html><body><p>Veröffentlicht am 1.9.17</p></body></html>', '2017-09-01', True),
         ('<html><body><p>Veröffentlicht am 1.9.17</p></body></html>', '2017-09-01', False),
     ]
@@ -240,6 +171,12 @@ def test_sitename():
         ('<html><head><meta name="article:publisher" content="The Newspaper"/></head><body/></html>', 'The Newspaper'),
         ('<html><head><meta property="article:publisher" content="The Newspaper"/></head><body/></html>', 'The Newspaper'),
         ('<html><head><title>sitemaps.org - Home</title></head><body/></html>', 'sitemaps.org'),
+        # fallback: derive the site name from the URL host
+        ('<html><head><meta property="og:url" content="https://www.example.org/article"/></head><body/></html>', 'example.org'),
+        # backup site name from application-name
+        ('<html><head><meta name="application-name" content="MySite"/></head><body/></html>', 'MySite'),
+        # a no-dot lowercase publisher is title-cased
+        ('<html><head><meta name="article:publisher" content="newspaper"/></head><body/></html>', 'Newspaper'),
     ]
 
     for doc, expected in tests:
@@ -262,6 +199,10 @@ def test_meta():
     assert metadata.url == 'https://example.org/test'
     assert metadata.license == 'Creative Commons'
 
+    # all OpenGraph fields present -> early return before the meta loop
+    metadata = extract_metadata('<html><head><meta property="og:title" content="T"/><meta property="og:author" content="A B"/><meta property="og:url" content="https://e.org"/><meta property="og:description" content="D"/><meta property="og:site_name" content="S"/><meta property="og:image" content="https://e.org/i.jpg"/></head><body/></html>')
+    assert metadata.title == 'T' and metadata.image == 'https://e.org/i.jpg'
+
     metadata = extract_metadata('<html><head><meta name="dc.title" content="Open Graph Title"/><meta name="dc.creator" content="Jenny Smith"/><meta name="dc.description" content="This is an Open Graph description"/></head><body></body></html>')
     assert metadata.title == 'Open Graph Title'
     assert metadata.author == 'Jenny Smith'
@@ -278,8 +219,9 @@ def test_meta():
     assert metadata.sitename is None
     metadata = extract_metadata('<html><head><title>' + 'AAA'*10000 + '</title></head></html>')
     assert metadata.title.endswith('…') and len(metadata.title) == 10000
-    assert extract_metadata('<html><head><meta otherkey="example" content="Unknown text"/></head></html>') is not None
-    assert extract_metadata('<html><head><title></title><title></title><title></title></head></html>') is not None
+    assert extract_metadata('<html><head><meta otherkey="example" content="Unknown text"/></head></html>').title is None
+    assert extract_metadata('<html><head><title></title><title></title><title></title></head></html>').title is None
+    assert extract_metadata('<html><body><script type="application/ld+json"></script></body></html>').title is None
 
 
 def test_catstags():
@@ -287,23 +229,34 @@ def test_catstags():
     assert normalize_tags("   ") == ""
     assert normalize_tags(" 1 &amp; 2 ") == "1 & 2"
 
-    htmldocs = [
-        '<html><body><p class="entry-categories"><a href="https://example.org/category/cat1/">Cat1</a>, <a href="https://example.org/category/cat2/">Cat2</a></p></body></html>',
-        '<html><body><div class="postmeta"><a href="https://example.org/category/cat1/">Cat1</a></div></body></html>',
-        '<html><body><p class="entry-tags"><a href="https://example.org/tags/tag1/">Tag1</a>, <a href="https://example.org/tags/tag2/">Tag2</a></p></body></html>',
-        '<html><head><meta name="keywords" content="sodium, salt, paracetamol, blood, pressure, high, heart, &amp;quot, intake, warning, study, &amp;quot, medicine, dissolvable, cardiovascular" /></head></html>',
+    cases = [
+        ('<html><body><p class="entry-categories"><a href="https://example.org/category/cat1/">Cat1</a>, <a href="https://example.org/category/cat2/">Cat2</a></p></body></html>', 'categories', ['Cat1', 'Cat2']),
+        ('<html><body><div class="postmeta"><a href="https://example.org/category/cat1/">Cat1</a></div></body></html>', 'categories', ['Cat1']),
+        ('<html><body><p class="entry-tags"><a href="https://example.org/tags/tag1/">Tag1</a>, <a href="https://example.org/tags/tag2/">Tag2</a></p></body></html>', 'tags', ['Tag1', 'Tag2']),
+        ('<html><head><meta name="keywords" content="sodium, salt, paracetamol, blood, pressure, high, heart, &amp;quot, intake, warning, study, &amp;quot, medicine, dissolvable, cardiovascular" /></head></html>', 'tags', ['sodium, salt, paracetamol, blood, pressure, high, heart, intake, warning, study, medicine, dissolvable, cardiovascular']),
+        # plural "/categories/" in the href must be recognised
+        ('<html><body><p class="entry-categories"><a href="https://example.org/categories/cat1/">Cat1</a></p></body></html>', 'categories', ['Cat1']),
+        # article:tag meta -> tags
+        ('<html><head><meta property="article:tag" content="Sports"/></head><body/></html>', 'tags', ['Sports']),
+        # category fallback via article:section meta (no category links)
+        ('<html><head><meta property="article:section" content="Politics"/></head><body/></html>', 'categories', ['Politics']),
     ]
-    attrs = ['categories', 'categories', 'tags', 'tags']
-    expected = [
-        ['Cat1', 'Cat2'],
-        ['Cat1'],
-        ['Tag1', 'Tag2'],
-        ['sodium, salt, paracetamol, blood, pressure, high, heart, intake, warning, study, medicine, dissolvable, cardiovascular'],
-    ]
+    for doc, attr, expected in cases:
+        assert getattr(extract_metadata(doc), attr) == expected
 
-    for doc, attr, expected_value in zip(htmldocs, attrs, expected):
-        metadata = extract_metadata(doc)
-        assert getattr(metadata, attr) == expected_value
+
+def test_date_config():
+    "A user date_config without 'max_date' must not raise, and must not be mutated."
+    cfg = {"original_date": True, "extensive_search": False}
+    doc = '<html><head><title>T</title></head><body><p>x</p></body></html>'
+    assert extract_metadata(doc, date_config=cfg) is not None
+    assert "url" not in cfg
+
+
+def test_extract_title_fallbacks():
+    "Fallback titles are trimmed; nothing found returns None."
+    assert extract_title(html.fromstring("<html><body><h1>  A  </h1><h1>B</h1></body></html>")) == "A"
+    assert extract_title(html.fromstring("<html><body><p>x</p></body></html>")) is None
 
 
 def test_license():
@@ -337,30 +290,27 @@ def test_license():
 	<span>The license is <a href="https://example.org/1">CC BY-NC</a></span>
 	</footer></body></html>''')
     assert metadata.license == 'CC BY-NC'
+    # license text wrapped in nested markup (text_content, not .text)
+    metadata = extract_metadata('<html><body><footer><a href="/x"><span>CC BY-SA 4.0</span></a></footer></body></html>')
+    assert metadata.license == 'CC BY-SA 4.0'
+    # a rel=license link with no href/text cue yields no license
+    metadata = extract_metadata('<html><body><p><a rel="license" href="/x"></a></p></body></html>')
+    assert metadata.license is None
 
 
 def test_images():
     '''Image extraction from meta SEO tags'''
-    htmldocs = [
-        '<html><head><meta property="image" content="https://example.org/example.jpg"></html>',
-        '<html><head><meta property="og:image:url" content="example.jpg"></html>',
-        '<html><head><meta property="og:image" content="https://example.org/example-opengraph.jpg" /><body/></html>',
-        '<html><head><meta property="twitter:image" content="https://example.org/example-twitter.jpg"></html>',
-        '<html><head><meta property="twitter:image:src" content="example-twitter.jpg"></html>',
-        '<html><head><meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" /></html>',
+    cases = [
+        ('<html><head><meta property="image" content="https://example.org/example.jpg"></html>', 'https://example.org/example.jpg'),
+        ('<html><head><meta property="og:image:url" content="example.jpg"></html>', 'example.jpg'),
+        ('<html><head><meta property="og:image" content="https://example.org/example-opengraph.jpg" /><body/></html>', 'https://example.org/example-opengraph.jpg'),
+        ('<html><head><meta property="twitter:image" content="https://example.org/example-twitter.jpg"></html>', 'https://example.org/example-twitter.jpg'),
+        ('<html><head><meta property="twitter:image:src" content="example-twitter.jpg"></html>', 'example-twitter.jpg'),
+        ('<html><head><meta name="twitter:image" content="https://example.org/example-name.jpg"></html>', 'https://example.org/example-name.jpg'),
+        ('<html><head><meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" /></html>', None),
     ]
-    expected_images = [
-        'https://example.org/example.jpg',
-        'example.jpg',
-        'https://example.org/example-opengraph.jpg',
-        'https://example.org/example-twitter.jpg',
-        'example-twitter.jpg',
-        None,
-    ]
-
-    for doc, expected_image in zip(htmldocs, expected_images):
-        metadata = extract_metadata(doc)
-        assert metadata.image == expected_image
+    for doc, expected in cases:
+        assert extract_metadata(doc).image == expected
 
 
 def test_document_as_dict():
@@ -406,12 +356,16 @@ def test_document_as_dict():
 
 if __name__ == '__main__':
     test_titles()
-    test_authors()
+    test_author_blacklist()
+    test_author_from_meta()
+    test_author_from_markup()
     test_dates()
     test_meta()
     test_url()
     test_description()
     test_catstags()
+    test_date_config()
+    test_extract_title_fallbacks()
     test_sitename()
     test_license()
     test_images()

--- a/trafilatura/json_metadata.py
+++ b/trafilatura/json_metadata.py
@@ -71,9 +71,10 @@ def is_plausible_sitename(metadata: Document, candidate: Any, content_type: Opti
 def process_parent(parent: Any, metadata: Document) -> Document:
     "Find and extract selected metadata from JSON parts."
     for content in filter(None, parent):  # type: Dict[str, Any]
-        # try to extract publisher
-        if 'publisher' in content and 'name' in content['publisher']:
-            metadata.sitename = content['publisher']['name']
+        # publisher may be a bare string, not a dict
+        publisher = content.get('publisher')
+        if isinstance(publisher, dict) and 'name' in publisher:
+            metadata.sitename = publisher['name']
 
         if '@type' not in content or not content["@type"]:
             continue
@@ -92,7 +93,7 @@ def process_parent(parent: Any, metadata: Document) -> Document:
                 metadata.sitename = candidate
 
         elif content_type == "person":
-            if content.get('name') and not content['name'].startswith('http'):
+            if isinstance(content.get('name'), str) and not content['name'].startswith('http'):
                 metadata.author = normalize_authors(metadata.author, content['name'])
 
         elif content_type in JSON_ARTICLE_SCHEMA:
@@ -111,6 +112,8 @@ def process_parent(parent: Any, metadata: Document) -> Document:
                     list_authors = [list_authors]
 
                 for author in list_authors:
+                    if isinstance(author, str):
+                        author = {"name": author}
                     if '@type' not in author or author['@type'] == 'Person':
                         author_name = None
                         # error thrown: author['name'] can be a list (?)
@@ -157,7 +160,7 @@ def extract_json(schema: Union[List[Any], Dict[str, str]], metadata: Document) -
             elif '@type' in parent and isinstance(parent['@type'], str) and 'liveblogposting' in parent['@type'].lower() and 'liveBlogUpdate' in parent:
                 parent = parent['liveBlogUpdate'] if isinstance(parent['liveBlogUpdate'], list) else [parent['liveBlogUpdate']]
             else:
-                parent = schema
+                return process_parent(schema, metadata)
 
             metadata = process_parent(parent, metadata)
 
@@ -168,8 +171,12 @@ def extract_json_author(elemtext: str, regular_expression: Pattern[str]) -> Opti
     '''Crudely extract author names from JSON-LD data'''
     authors = None
     mymatch = regular_expression.search(elemtext)
-    while mymatch and ' ' in mymatch[1]:
-        authors = normalize_authors(authors, mymatch[1])
+    while mymatch:
+        # first matching group (JSON_AUTHOR_1 has two)
+        name = next(filter(None, mymatch.groups()), None)
+        if not name or ' ' not in name:
+            break
+        authors = normalize_authors(authors, name)
         elemtext = regular_expression.sub(r'', elemtext, count=1)
         mymatch = regular_expression.search(elemtext)
     return authors or None
@@ -265,11 +272,12 @@ def normalize_authors(current_authors: Optional[str], author_string: str) -> Opt
         if not author or (len(author) >= 50 and ' ' not in author and '-' not in author):
             continue
         # title case
-        if not author[0].isupper() or sum(1 for c in author if c.isupper()) < 1:
+        if not author[0].isupper():
             author = author.title()
-        # safety checks
-        if author not in new_authors and (len(new_authors) == 0 or all(new_author not in author for new_author in new_authors)):
+        if author not in new_authors:
             new_authors.append(author)
+    # keep only the fullest form of each name (drop names contained in another)
+    new_authors = [n for n in new_authors if not any(n != m and n in m for m in new_authors)]
     if len(new_authors) == 0:
         return current_authors
     return '; '.join(new_authors).strip('; ')

--- a/trafilatura/metadata.py
+++ b/trafilatura/metadata.py
@@ -370,13 +370,13 @@ def extract_title(tree: HtmlElement) -> Optional[str]:
             return t
     # take first h1-title
     if h1_results:
-        return h1_results[0].text_content()
+        return trim(h1_results[0].text_content())
     # take first h2-title
     try:
-        title = tree.xpath(".//h2")[0].text_content()
+        title = trim(tree.xpath(".//h2")[0].text_content())
     except IndexError:
         LOGGER.debug("no h2 title found")
-    return title
+    return title or None
 
 
 def extract_author(tree: HtmlElement) -> Optional[str]:
@@ -425,7 +425,7 @@ def extract_sitename(tree: HtmlElement) -> Optional[str]:
 def extract_catstags(metatype: str, tree: HtmlElement) -> List[str]:
     """Find category and tag information"""
     results: List[str] = []
-    regexpr = "/" + metatype + "[s|ies]?/"
+    regexpr = "/" + metatype.rstrip("y") + "(?:y|ies|s)?/"
     xpath_expression = CATEGORIES_XPATHS if metatype == "category" else TAGS_XPATHS
     # search using custom expressions
     for catexpr in xpath_expression:
@@ -456,12 +456,14 @@ def parse_license_element(element: HtmlElement, strict: bool = False) -> Optiona
     match = LICENSE_REGEX.search(element.get("href", ""))
     if match:
         return f"CC {match[1].upper()} {match[2]}"
-    if element.text:
+    # use text_content() to also catch text wrapped in nested markup
+    text = trim(element.text_content())
+    if text:
         # check if it could be a CC license
         if strict:
-            match = TEXT_LICENSE_REGEX.search(element.text)
+            match = TEXT_LICENSE_REGEX.search(text)
             return match[0] if match else None
-        return trim(element.text)
+        return text
     return None
 
 
@@ -495,15 +497,16 @@ def extract_metadata(
         filecontent: HTML code as string or parsed tree.
         default_url: Previously known URL of the downloaded document.
         date_config: Provide extraction parameters to htmldate as dict().
+        extensive: Use extensive search for date extraction.
         author_blacklist: Provide a blacklist of Author Names as set() to filter out authors.
 
     Returns:
-        A trafilatura.settings.Document containing the extracted metadata information or None.
+        A trafilatura.settings.Document containing the extracted metadata information.
         The Document class has .as_dict() method that will return a copy as a dict.
     """
     # init
     author_blacklist = author_blacklist or set()
-    date_config = date_config or set_date_params(extensive)
+    date_config = {**date_config} if date_config else set_date_params(extensive)
 
     # load contents
     tree = load_html(filecontent)
@@ -586,7 +589,7 @@ def extract_metadata(
     metadata.license = extract_license(tree)
 
     # safety checks
-    metadata.filedate = date_config["max_date"]
+    metadata.filedate = date_config.get("max_date")
     metadata.clean_and_trim()
 
     return metadata


### PR DESCRIPTION
Extend test coverage on metadata extraction, especially author and publisher. Harden the main code to prevent future issues.
FYI @felipehertzer 