### PR TITLE
fix: keep space after inline formatting in Markdown list items

### DIFF
--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -487,7 +487,7 @@ trafilatura.extract("")
         Test</article></body></html>
     """)
     my_result = extract(my_document, output_format="markdown", include_links=True, config=ZERO_CONFIG)
-    assert my_result == "- Number 0\n- Number [1](test.html)\n- [Number 2](test.html)n2\n- Number 3\n- Number 4 n4\n\nTest"
+    assert my_result == "- Number 0\n- Number [1](test.html)\n- [Number 2](test.html) n2\n- Number 3\n- Number 4 n4\n\nTest"
     # XML and Markdown formatting within <p>-tag
     my_document = html.fromstring(
         '<html><body><p><b>bold</b>, <i>italics</i>, <tt>tt</tt>, <strike>deleted</strike>, <u>underlined</u>, <a href="test.html">link</a> and additional text to bypass detection.</p></body></html>'
@@ -578,6 +578,12 @@ def test:
 ```"""
         == my_result
     )
+
+
+def test_markdown_list_item_inline_spacing():
+    """Inline formatting tails inside list items must keep their leading space (issue #845)"""
+    htmlstring = "<html><body><article><ol><li>Foo <em>bar</em> baz.</li></ol></article></body></html>"
+    assert extract(htmlstring, output_format="markdown", config=ZERO_CONFIG) == "- Foo *bar* baz."
 
 
 def test_extract_with_metadata():

--- a/trafilatura/xml.py
+++ b/trafilatura/xml.py
@@ -20,6 +20,7 @@ from .utils import (
     is_in_table_cell,
     is_last_element_in_cell,
     is_last_element_in_item,
+    line_processing,
     sanitize,
     sanitize_tree,
     text_chars_test,
@@ -403,7 +404,14 @@ def process_element(element: _Element, returnlist: list[str], include_formatting
     # unless it's within a list item or a table
     is_in_cell = is_in_table_cell(element)
     if element.tail and not is_in_cell:
-        returnlist.append(element.tail.strip() if is_element_in_item(element) or element.tag == "list" else element.tail)
+        if is_element_in_item(element) and element.tag in SPECIAL_FORMATTING:
+            # inline formatting elements get no trailing space appended above, so
+            # keep a single leading/trailing space in the tail (e.g. "*bar* baz")
+            normalized_tail = line_processing(element.tail, trailing_space=True)
+            if normalized_tail:
+                returnlist.append(normalized_tail)
+        else:
+            returnlist.append(element.tail.strip() if is_element_in_item(element) or element.tag == "list" else element.tail)
 
     # deal with list items alone
     if is_last_element_in_item(element) and not is_in_cell:


### PR DESCRIPTION
closes #845

Inside a list item, `process_element()` stripped the tail of every child element. For inline formatting elements (`<hi>`/`<ref>` in `SPECIAL_FORMATTING`) no trailing space is appended by the earlier spacing logic, so the leading space of the tail (" baz.") is the only separator between them and the following text — `.strip()` removed it and produced `*bar*baz.`. Block elements inside an item do get a trailing space appended, so their tails still need stripping to avoid a double space.

So for inline-formatting tails inside items, run them through the existing `line_processing(..., trailing_space=True)` (collapses internal whitespace, keeps a single leading/trailing space, drops whitespace-only tails); every other case keeps the original behaviour.

Added a regression test (verified it fails without the change), and corrected one existing assertion in `test_formatting` that had the same bug baked in for a link inside a list item. unit/realworld/xml_tei tests pass locally, and mypy + ruff (check and format) are clean.