### PR TITLE
fix: keep list items whose only content is a link

### DIFF
--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -1801,6 +1801,19 @@ def test_list_processing():
     item_element = processed_list[0]
     assert item_element.tail is not True
     assert item_element[0].tail == "tail"
+    # list items whose only content is a link must be kept (GH #788)
+    htmlstring = """<html><body><article>
+<p>If your eye is twitching and you do not have other symptoms, here are some common everyday causes worth knowing about.</p>
+<ul>
+<li><p><a href="https://example.org/stress">Stress</a></p></li>
+<li><p>Fatigue</p></li>
+<li><p><a href="https://example.org/strain">Eye strain</a></p></li>
+</ul>
+</article></body></html>"""
+    my_result = extract(htmlstring, fast=True, output_format="markdown", include_links=True, config=ZERO_CONFIG)
+    assert "[Stress](https://example.org/stress)" in my_result
+    assert "Fatigue" in my_result
+    assert "[Eye strain](https://example.org/strain)" in my_result
     list_item_with_child_and_tail = html.fromstring("<list><item><p>text</p>tail1</item>tail</list>")
     processed_list = handle_lists(list_item_with_child_and_tail, options)
     item_element = processed_list[0]

--- a/trafilatura/htmlprocessing.py
+++ b/trafilatura/htmlprocessing.py
@@ -195,6 +195,12 @@ def delete_by_link_density(
         elemtext = trim(elem.text_content())
         result, templist = link_density_test(elem, elemtext, favor_precision)
         if result or (backtracking and templist and 0 < len(elemtext) < len_threshold and len(elem) >= depth_threshold):
+            # a paragraph that holds the content of a list item is kept: the
+            # link density of the whole list is checked separately, and
+            # removing it here would leave the item empty (GH #788)
+            parent = elem.getparent()
+            if tagname == "p" and parent is not None and parent.tag == "item":
+                continue
             deletions.append(elem)
             # else: # and not re.search(r'[?!.]', text):
             # print(elem.tag, templist)


### PR DESCRIPTION
When a list item's only content is a link, `delete_by_link_density`'s per-`<p>` pass flags that paragraph as boilerplate (link-text/total ratio ~1.0) and removes it, leaving an empty `<item>` — so the bullet vanishes from the output. The whole-list link density is already checked separately in the preceding `delete_by_link_density(tree, "list", ...)` pass, so the per-`<p>` pass shouldn't also gut surviving list items.

Skip deletion of a paragraph whose direct parent is an `item`. Genuinely link-heavy lists are still dropped wholesale by the list pass.

Added a case to `test_list_processing` (markdown + `include_links=True`) asserting all three items survive; it fails before the change and passes after.

closes #788