### PR TITLE
fix: keep Yoast FAQ block question headers

### DIFF
--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -596,6 +596,34 @@ def test:
     )
 
 
+def test_yoast_faq_block():
+    "Yoast FAQ block questions are bold but act as headers and must be kept (issue #471)."
+    # a long lead paragraph keeps <div> out of the potential tags, as on the reported page
+    lead = (
+        "The wrap dress is a dress with a front closure formed by wrapping one side across the other "
+        "and knotting the attached ties that wrap around the back at the waist or fastening buttons. "
+        "It was popularised in the seventies and has remained a wardrobe staple ever since, flattering "
+        "many different body shapes thanks to its adjustable and forgiving cut. " * 2
+    )
+    htmlstring = (
+        "<html><body><article><h1>Wrap dress</h1><p>" + lead + "</p>"
+        '<div class="schema-faq wp-block-yoast-faq-block">'
+        '<div class="schema-faq-section" id="faq-question-1">'
+        '<strong class="schema-faq-question">Who invented the wrap dress?</strong> '
+        '<p class="schema-faq-answer">It was popularised by Diane von Furstenberg in 1974.</p>'
+        "</div></div></article></body></html>"
+    )
+    # default (no formatting): the question must not be dropped
+    assert "Who invented the wrap dress?" in extract(htmlstring, config=ZERO_CONFIG)
+    # with formatting: it is rendered as a header
+    assert "### Who invented the wrap dress?" in extract(
+        htmlstring, output_format="txt", include_formatting=True, config=ZERO_CONFIG
+    )
+    assert '<head rend="h3">Who invented the wrap dress?</head>' in extract(
+        htmlstring, output_format="xml", config=ZERO_CONFIG
+    )
+
+
 def test_include_formatting_markdown():
     "markdown defaults to formatted, but an explicit include_formatting=False is honored (was ignored for markdown)."
     doc = "<html><body><article><p>plain and <b>bold</b> text here.</p></article></body></html>"

--- a/trafilatura/htmlprocessing.py
+++ b/trafilatura/htmlprocessing.py
@@ -393,6 +393,12 @@ def convert_tags(tree: HtmlElement, options: Extractor, url: str | None = None) 
         for elem in tree.iter("a", "ref"):
             convert_link(elem, base_url)
 
+    # Yoast FAQ blocks: question headers are bold but act as titles (#471)
+    for elem in tree.xpath('.//strong[contains(@class, "schema-faq-question")]'):
+        elem.attrib.clear()
+        elem.set("rend", "h3")
+        elem.tag = "head"
+
     if options.formatting:
         for elem in tree.iter(REND_TAG_MAPPING.keys()):
             elem.attrib.clear()


### PR DESCRIPTION
closes #471

Yoast FAQ blocks render each question as `<strong class="schema-faq-question">`. The bold question acts as a section header on the page, but trafilatura treated it as inline bold, so it got flattened or dropped depending on the options.

In `convert_tags` I retag those `<strong>` elements to `<head rend="h3">` so they survive extraction and come out as headers (### in Markdown, `<head rend="h3">` in XML). Added a test covering the default, formatted, and XML output.