### PR TITLE
Quote metadata values to keep the Markdown header valid YAML (#814)

### DIFF
--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -622,6 +622,49 @@ def test:
     assert "AP-fonden" in my_result
 
 
+def test_markdown_metadata_yaml_safe():
+    "Markdown metadata header must stay valid YAML for special values (GH #814)."
+    # scalar rendering: plain when safe, double-quoted (json) otherwise
+    assert core._yaml_scalar("Indu K Murthy") == "Indu K Murthy"
+    assert core._yaml_scalar("https://example.com/a:b") == "https://example.com/a:b"
+    assert core._yaml_scalar("élan vital") == "élan vital"
+    assert core._yaml_scalar("COP30: a guide") == '"COP30: a guide"'
+    assert core._yaml_scalar("#1 ranking") == '"#1 ranking"'
+    assert core._yaml_scalar("&launch") == '"&launch"'
+    assert core._yaml_scalar("true") == '"true"'
+    assert core._yaml_scalar("2024") == '"2024"'
+    assert core._yaml_scalar("[draft]") == '"[draft]"'
+    assert core._yaml_scalar('say "hi": now') == '"say \\"hi\\": now"'
+
+    # the rendered scalars must round-trip exactly through a real YAML parser
+    yaml = pytest.importorskip("yaml")
+    for value in (
+        "COP30: a beginner’s guide",
+        "#1 ranking",
+        "&launch",
+        "true",
+        "[draft] note",
+        'a "quoted" word',
+        "Indu K Murthy",
+    ):
+        loaded = yaml.safe_load("title: " + core._yaml_scalar(value))
+        assert loaded["title"] == value
+
+    # end-to-end: a title with ": " used to emit invalid YAML, now it is quoted
+    my_html = (
+        "<html><head><title>COP30: a beginner’s guide</title>"
+        '<meta name="author" content="Indu K Murthy"/></head>'
+        "<body><article><p>Some body text with enough words to be extracted.</p>"
+        "</article></body></html>"
+    )
+    result = extract(my_html, output_format="markdown", config=ZERO_CONFIG, with_metadata=True)
+    header = result.split("---\n", 2)[1]
+    meta = yaml.safe_load(header)
+    assert meta["title"] == "COP30: a beginner’s guide"
+    assert meta["author"] == "Indu K Murthy"
+    assert 'title: "COP30: a beginner’s guide"' in result
+
+
 def test_blockquote_inline_content():
     "Inline formatting, links, and images inside blockquotes must be preserved."
     assert _md_inline("<blockquote><p>A <b>bold</b> word</p></blockquote>") == f"{_INTRO}\n\nA **bold** word"

--- a/trafilatura/core.py
+++ b/trafilatura/core.py
@@ -3,6 +3,7 @@
 Extraction configuration and processing functions.
 """
 
+import json
 import logging
 import warnings
 from configparser import ConfigParser
@@ -38,6 +39,28 @@ from .xpaths import REMOVE_COMMENTS_XPATH
 LOGGER = logging.getLogger(__name__)
 
 TXT_FORMATS = {"markdown", "txt"}
+
+# Metadata is emitted as a YAML-style Markdown header; values such as a title
+# containing ": " (or a leading indicator, or a reserved word) otherwise produce
+# invalid YAML or get reinterpreted as a non-string. See GH #814.
+_YAML_RESERVED = frozenset({"true", "false", "yes", "no", "on", "off", "y", "n", "null", "none", "~"})
+
+
+def _yaml_scalar(value: str) -> str:
+    "Render a metadata string as a plain or double-quoted YAML-safe scalar."
+    if (
+        value
+        and value == value.strip()
+        and value[0].isalpha()
+        and ": " not in value
+        and " #" not in value
+        and not value.endswith(":")
+        and value.lower() not in _YAML_RESERVED
+        and all(ch >= " " and ch != "\x7f" for ch in value)
+    ):
+        return value
+    # a JSON string is always a valid, exactly round-tripping YAML double-quoted scalar
+    return json.dumps(value, ensure_ascii=False)
 
 
 def determine_returnstring(document: Document, options: Extractor) -> str:
@@ -80,8 +103,13 @@ def determine_returnstring(document: Document, options: Extractor) -> str:
                 "id",
                 "license",
             ):
-                if getattr(document, attr):
-                    header += f"{attr}: {str(getattr(document, attr))}\n"
+                value = getattr(document, attr)
+                if value:
+                    # quote scalar strings when needed; categories/tags are lists
+                    # rendered as their (already valid) flow-sequence repr
+                    if isinstance(value, str):
+                        value = _yaml_scalar(value)
+                    header += f"{attr}: {value}\n"
             header += "---\n"
         else:
             header = ""


### PR DESCRIPTION
Fixes #814.

The Markdown/TXT metadata header interpolates each value raw:

```python
header += f"{attr}: {str(getattr(document, attr))}\n"
```

so a title like `COP30: a beginner's guide` is written as `title: COP30: a beginner's guide`, which isn't valid YAML (the `: ` reads as a second mapping key). Values are also silently reinterpreted on parse: `true`/`null` become a bool/null, a leading `#` starts a comment (→ null), a leading `&`/`*`/`[` is an anchor/alias/sequence, and so on.

`_yaml_scalar()` renders each scalar string safely: bare when it is unambiguous (ordinary titles, author names and URLs are unchanged), otherwise double-quoted via `json.dumps()`. A JSON string is always a valid YAML double-quoted scalar that round-trips exactly, so this stays dependency-free and covers colons, quotes, leading indicators, reserved words and numerics uniformly. `categories`/`tags` are lists and keep their existing `['a', 'b']` flow-sequence form, which is already valid YAML.

`test_markdown_metadata_yaml_safe` renders the scalars directly, round-trips a range of adversarial values through PyYAML (`importorskip`), and checks end-to-end that a `: `-containing title now produces a header that parses as valid YAML with the title preserved exactly. `pytest`, `mypy -p trafilatura` and `ruff check`/`ruff format` are clean.

Happy to add a HISTORY.md entry under whichever section you prefer.
