### PR TITLE
docs: add example for adapting element lists in Python

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -126,5 +126,32 @@ Here is how to change them:
 These remaining variables greatly alter the functioning of the package!
 
 
+Adapting element lists in Python
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Some of these variables are Python lists which can also be adapted on the fly, without editing and reinstalling the package. This is convenient to discard or keep particular HTML elements, e.g. for documents which are not news articles. The lists ``MANUALLY_CLEANED`` (elements removed along with their content) and ``MANUALLY_STRIPPED`` (elements whose tags are removed but whose text is kept) have to be modified **in place**, so that the changes are seen by the extraction functions:
+
+.. code-block:: python
+
+    >>> from trafilatura import extract
+    >>> from trafilatura.settings import MANUALLY_CLEANED, MANUALLY_STRIPPED
+
+    # discard additional elements along with their content
+    >>> MANUALLY_CLEANED.append("section")
+
+    # remove the tags of additional elements but keep their text
+    >>> MANUALLY_STRIPPED.append("u")
+
+    # keep elements which are discarded by default
+    >>> MANUALLY_CLEANED.remove("aside")
+
+    # the changes affect all subsequent extractions
+    >>> extract(my_document)
+
+
+.. warning::
+    Use the in-place methods ``.append()``, ``.remove()`` or ``.extend()``. Reassigning the names (e.g. ``MANUALLY_CLEANED = [...]``) only rebinds the local variable and has no effect on extraction. These lists are global to the process, so the change applies to all following extractions.
+
+
 .. hint::
     Starting from version 1.9, most extraction parameters and options can be defined in an object which is then passed to the extraction functions instead of the arguments and (in some cases) instead of the config file. See ``settings.py`` for an example.

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -2689,6 +2689,34 @@ def test_config_loading():
     assert options.min_output_size == use_config().getint("DEFAULT", "MIN_OUTPUT_SIZE")
 
 
+def test_settings_element_lists():
+    "Modifying MANUALLY_CLEANED/MANUALLY_STRIPPED in place affects extraction (issue #746)."
+    from trafilatura.settings import MANUALLY_CLEANED
+
+    html = (
+        "<html><body><div>"
+        "<p>Alpha paragraph number one with more than enough length to be considered real body content.</p>"
+        "<blockquote>Quoted block of text which is normally retained within the trafilatura extraction output.</blockquote>"
+        "<p>Beta paragraph number two also with more than enough length to be treated as real body content.</p>"
+        "<p>Gamma paragraph number three providing extra padding for the document body content section here.</p>"
+        "<p>Delta paragraph number four keeping the extracted text comfortably above the minimum size limit.</p>"
+        "</div></body></html>"
+    )
+
+    # by default the blockquote and its content are part of the output
+    assert "Quoted block" in extract(html, fast=True)
+
+    # documented usage: an in-place change discards the element and its content
+    MANUALLY_CLEANED.append("blockquote")
+    try:
+        assert "Quoted block" not in extract(html, fast=True)
+    finally:
+        MANUALLY_CLEANED.remove("blockquote")
+
+    # restoring the list restores the default behavior
+    assert "Quoted block" in extract(html, fast=True)
+
+
 def test_is_probably_readerable():
     """
     Test is_probably_readerable function.


### PR DESCRIPTION
closes #746

The settings docs note that some variables are Python lists but never show how to change them. Added a short section to docs/settings.rst with examples for modifying MANUALLY_CLEANED and MANUALLY_STRIPPED in place (append/remove/extend), plus a warning that reassigning the names has no effect since the lists are global to the process and the extraction functions read the existing objects.

Also added a test confirming that an in-place change to MANUALLY_CLEANED actually affects extraction output, and that removing the change restores the default.