### PR TITLE
Fix small <article>/<main> bodies extracted twice (#879)

### DIFF
--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -1957,6 +1957,23 @@ def test_no_duplicate_content():
     assert (extract(dup768, output_format="txt", config=real_config) or "").count("Line that has to have") == 1
     dup817 = "<html><body><div id='content'><p>Authoritative taxonomy of but let us leave it as it is 1 2 3</p></div><p>some text long enough not to skip and printed twice on this line some text long enough not to skip and printed twice on this line</p></body></html>"
     assert (extract(dup817, output_format="txt", config=real_config) or "").count("Authoritative taxonomy") == 1
+    # #879: a small <article>/<main> body (below min_extracted_size) triggers wild-text
+    # recovery which must not re-append paragraphs already collected by the main extractor
+    dup879 = (
+        "<html><body><nav>menu chrome</nav><article>"
+        "<h1>The Example Chronicle</h1>"
+        "<p>First synthetic paragraph of adequate length for extraction to engage properly.</p>"
+        "<p>Second synthetic paragraph, also long enough to matter for the extractor.</p>"
+        "</article><footer>footer chrome</footer></body></html>"
+    )
+    out879 = extract(dup879, output_format="txt", config=real_config) or ""
+    assert out879.count("First synthetic paragraph") == 1
+    assert out879.count("Second synthetic paragraph") == 1
+    # same trigger with a <main> wrapper
+    dup879_main = dup879.replace("article>", "main>")
+    out879_main = extract(dup879_main, output_format="txt", config=real_config) or ""
+    assert out879_main.count("First synthetic paragraph") == 1
+    assert out879_main.count("Second synthetic paragraph") == 1
 
 
 def test_list_item_block_child_single_bullet():

--- a/trafilatura/main_extractor.py
+++ b/trafilatura/main_extractor.py
@@ -774,15 +774,18 @@ def extract_content(cleaned_tree: HtmlElement, options: Extractor) -> tuple[_Ele
     if len(result_body) == 0 or len(temp_text) < options.min_extracted_size:
         result_body = recover_wild_text(backup_tree, result_body, options, potential_tags)
         temp_text = " ".join(result_body.itertext()).strip()
-    # drop substantial elements repeating the previous one (overlapping-candidate / recovery artifact);
-    # length-gated so short genuine repeats stay for the dedup (#778) and tree-size guards
-    previous = None
+    # drop substantial elements repeating an earlier one (overlapping-candidate / recovery artifact);
+    # length-gated so short genuine repeats stay for the dedup (#778) and tree-size guards.
+    # #879: wild-text recovery can re-append blocks already collected by the main extractor,
+    # interleaved rather than adjacent (head, p1, p2, p1, p2), so compare against all earlier
+    # substantial blocks instead of only the immediately preceding one.
+    seen: set[str] = set()
     for el in list(result_body):
         current = trim("".join(el.itertext()))
-        if current and current == previous and len(current) > DUPLICATE_ADJACENT_LIMIT:
+        if current and current in seen and len(current) > DUPLICATE_ADJACENT_LIMIT:
             delete_element(el, keep_tail=False)
-        else:
-            previous = current
+        elif current:
+            seen.add(current)
     # filter output
     strip_elements(result_body, "done")
     strip_tags(result_body, "div")


### PR DESCRIPTION
Fixes #879.

## Root cause

For a small document whose main content sits in a semantic container (`<article>` or `<main>`), the main extractor collects the paragraphs into `result_body`. Because the body text is below `min_extracted_size`, `extract_content` then calls `recover_wild_text` on the backup tree, which re-appends the same `<p>` elements. The resulting body is `[head, p1, p2, p1, p2]`.

The existing post-recovery dedup loop only compared each block against the **immediately preceding** one (`current == previous`). Here the duplicates are **interleaved** (`p1, p2, p1, p2`), not adjacent, so the loop never matched and every paragraph was emitted twice.

A `<div>` wrapper or a larger body avoids this: a bare `<div>` isn't populated by the body XPaths (recovery then adds the paragraphs once), and a larger body clears `min_extracted_size` so recovery never runs.

## Reproduction

```python
from trafilatura import extract

html = (
    "<html><body><nav>menu chrome</nav><article>"
    "<h1>The Example Chronicle</h1>"
    "<p>First synthetic paragraph of adequate length for extraction to engage properly.</p>"
    "<p>Second synthetic paragraph, also long enough to matter for the extractor.</p>"
    "</article><footer>footer chrome</footer></body></html>"
)
print(extract(html, output_format="markdown"))
```

Wrong output on 2.1.0 / `master` (both paragraphs doubled):

```
# The Example Chronicle

First synthetic paragraph of adequate length for extraction to engage properly.

Second synthetic paragraph, also long enough to matter for the extractor.

First synthetic paragraph of adequate length for extraction to engage properly.

Second synthetic paragraph, also long enough to matter for the extractor.
```

Corrected output with this change:

```
# The Example Chronicle

First synthetic paragraph of adequate length for extraction to engage properly.

Second synthetic paragraph, also long enough to matter for the extractor.
```

`<main>` reproduces identically and is likewise fixed.

## Fix

In `extract_content`, the post-recovery dedup now compares each substantial block against **all earlier** blocks (a `seen` set) instead of only the immediately preceding one. It keeps the existing `DUPLICATE_ADJACENT_LIMIT` length gate, so short genuine repeats still survive (per #778).

This is deliberately localized to the dedup loop rather than to `recover_wild_text`: the loop runs **after** `temp_text` length is captured for the baseline-fallback decision, so removing the visual duplicate does not push the (correct) text below `min_extracted_size` and does not alter which downstream path runs — formatting and the fallback threshold are preserved. Fixing `recover_wild_text` directly instead would drop the deduplicated text under the threshold and trigger the lossy baseline path, degrading the `<article>` output.

## Tests

- Extended `test_no_duplicate_content` in `tests/unit_tests.py` with the `<article>` and `<main>` triggers, asserting each paragraph appears exactly once. It fails on unmodified `master` (`assert 2 == 1`) and passes with this change.
- Verified short genuine repeats (below the length gate) and distinct multi-paragraph content are unaffected.
- `pytest tests/unit_tests.py tests/baseline_tests.py tests/deduplication_tests.py tests/filters_tests.py tests/metadata_tests.py tests/realworld_tests.py tests/json_metadata_tests.py tests/xml_tei_tests.py` — 186 passed, 2 skipped.
- `ruff check .` clean, `ruff format --check` clean, `mypy trafilatura/` introduces no new errors (the single pre-existing `zstandard` stub error is unrelated).

Disclosure: prepared with AI assistance; reviewed and verified locally.
