### PR TITLE
Fix duplicate paragraph recovery for short extraction fallback

### DIFF
--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -486,6 +486,17 @@ trafilatura.extract("")
     my_document = html.fromstring("<html><body><article><div><strong>Wild text</strong></div></article></body></html>")
     my_result = extract(my_document, config=ZERO_CONFIG)
     assert my_result == "Wild text"
+    # short article recovery should not duplicate already extracted paragraphs
+    my_document = html.fromstring(
+        "<html><body><nav>menu chrome</nav><article><h1>The Example Chronicle</h1>"
+        "<p>First synthetic paragraph of adequate length for extraction to engage properly.</p>"
+        "<p>Second synthetic paragraph, also long enough to matter for the extractor.</p>"
+        "</article><footer>footer chrome</footer></body></html>"
+    )
+    my_result = extract(my_document, output_format="markdown")
+    assert "The Example Chronicle" in my_result
+    assert my_result.count("First synthetic paragraph of adequate length for extraction to engage properly.") == 1
+    assert my_result.count("Second synthetic paragraph, also long enough to matter for the extractor.") == 1
     # links
     doc = html.fromstring('<html><body><p><a href="">Link text</a></p></body></html>')
     my_result = extract(doc, config=ZERO_CONFIG)


### PR DESCRIPTION
Fixes #660.

## Summary
- skip recovered wild-text nodes when their normalized text is already present in the extracted body
- keep the short-document fallback focused on missing content instead of duplicating paragraphs
- add a regression test that asserts the recovered markdown output does not repeat the same article paragraphs

## Validation
- `uv run --directory E:\CodexGitHubScout\trafilatura --extra dev pytest tests/unit_tests.py -q --basetemp=E:\CodexGitHubScout\tmp\pytest-trafilatura-full-20260717-1200`
- `uv run --directory E:\CodexGitHubScout\trafilatura --extra dev pytest tests/unit_tests.py -q -k "test_formatting or test_loose_text_tail_not_squished" --basetemp=E:\CodexGitHubScout\tmp\pytest-trafilatura-20260717-1200-postformat`
- `uv run --directory E:\CodexGitHubScout\trafilatura --extra dev ruff check trafilatura/main_extractor.py tests/unit_tests.py`
- `uv run --directory E:\CodexGitHubScout\trafilatura --extra dev ruff format --check trafilatura/main_extractor.py tests/unit_tests.py`
- `uv run --directory E:\CodexGitHubScout\trafilatura --extra dev --with zstandard mypy trafilatura/main_extractor.py`