### PR TITLE
fix: match image extensions case-insensitively in is_image_file

### DIFF
--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -838,7 +838,12 @@ def test_images(options):
     assert is_image_file(None) is False
     assert is_image_file("") is False
     assert is_image_file("test.jpg") is True
+    # Extensions are case-insensitive by convention (e.g. camera output IMG_1234.JPG).
+    assert is_image_file("test.JPG") is True
+    assert is_image_file("PIC.PNG") is True
+    assert is_image_file("photo.JPEG") is True
     assert is_image_file("test.txt") is False
+    assert is_image_file("test.TXT") is False
     assert is_image_file("test.jpg" * 2000) is False  # length threshold
     # tag with attributes
     assert handle_image(None) is None

--- a/trafilatura/utils.py
+++ b/trafilatura/utils.py
@@ -84,7 +84,7 @@ LINES_TRIMMING = re.compile(r"(?<![p{P}>])\n", flags=re.UNICODE | re.MULTILINE)
 URL_BLACKLIST_REGEX = re.compile(r"^https?://|/+$")
 
 # Regex to check image file extensions
-IMAGE_EXTENSION = re.compile(r"[^\s]+\.(avif|bmp|gif|hei[cf]|jpe?g|png|webp)(\b|$)")
+IMAGE_EXTENSION = re.compile(r"[^\s]+\.(avif|bmp|gif|hei[cf]|jpe?g|png|webp)(\b|$)", re.I)
 
 FORMATTING_PROTECTED = {"cell", "head", "hi", "item", "p", "quote", "ref", "td"}
 SPACING_PROTECTED = {"code", "pre"}


### PR DESCRIPTION
### What's broken

The `IMAGE_EXTENSION` regex lacks the `re.I` flag:

```python
IMAGE_EXTENSION = re.compile(r"[^\s]+\.(avif|bmp|gif|hei[cf]|jpe?g|png|webp)(\b|$)")
```

So `is_image_file` rejects uppercase / mixed-case extensions:

```python
is_image_file("test.jpg")   # True
is_image_file("test.JPG")   # False  <- should be True
is_image_file("PIC.PNG")    # False  <- should be True
```

Uppercase extensions are extremely common in the wild (camera output like `IMG_1234.JPG`, older CMS/Windows URLs). `handle_image` gates the `src` through `is_image_file`, so an `<img src=".../test.JPG">` is silently dropped from extraction while the lowercase equivalent is kept.

### Fix

Add `re.I`. File extensions are case-insensitive by convention, and sibling constants in the same file (`DOCTYPE_TAG`, `FAULTY_HTML`) already use `re.I`.

### Tests

Extends the existing `test_images` with uppercase/mixed-case assertions (`.JPG`, `.PNG`, `.JPEG` → image; `.TXT` → not). Full image test group passes.