### PR TITLE
fix: keep sup and sub boundaries in Markdown output

### DIFF
--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -721,6 +721,35 @@ def test_markdown_list_item_inline_spacing():
     assert extract(htmlstring, output_format="markdown", config=ZERO_CONFIG) == "1. Foo *bar* baz."
 
 
+def test_markdown_sup_sub_keep_boundary():
+    """sup/sub must keep a boundary, else 100<sup>2</sup> reads as 1002 (issue #889)"""
+    sup = "<html><body><article><p>The layer has 100<sup>2</sup>=10000 nodes.</p></article></body></html>"
+    sub = "<html><body><article><p>Written 2011<sub>15ya</sub> in winter.</p></article></body></html>"
+    assert extract(sup, output_format="markdown", config=ZERO_CONFIG) == "The layer has 100<sup>2</sup>=10000 nodes."
+    assert extract(sub, output_format="markdown", config=ZERO_CONFIG) == "Written 2011<sub>15ya</sub> in winter."
+    # flanking whitespace stays outside the tags, exactly as for the symmetric markers
+    spaced = "<html><body><article><p>x <sup> 2 </sup> y</p></article></body></html>"
+    bold = "<html><body><article><p>x <b> 2 </b> y</p></article></body></html>"
+    assert extract(spaced, output_format="markdown", config=ZERO_CONFIG) == "x  <sup>2</sup>  y"
+    assert extract(bold, output_format="markdown", config=ZERO_CONFIG) == "x  **2**  y"
+
+
+def test_markdown_empty_sup_sub_are_dropped():
+    """An empty sup/sub must be removed without taking the text after it (issue #889)"""
+    # process_node() hands a textless element its tail as text, so without the removal in
+    # convert_tags() the new marker would wrap the *following* words: a<sup>b</sup>
+    for tag in ("sup", "sub"):
+        doc = f"<html><body><article><p>a<{tag}></{tag}>b</p></article></body></html>"
+        assert extract(doc, output_format="markdown", config=ZERO_CONFIG) == "ab"
+    # a footnote marker whose only child is dropped must still not swallow the sentence
+    footnote = '<html><body><article><p>Fact<sup><img src="x.png"/></sup> follows here.</p></article></body></html>'
+    assert extract(footnote, output_format="markdown", config=ZERO_CONFIG) == "Fact follows here."
+    # the tail survives in precision mode too, where CUT_EMPTY_ELEMS pruning would drop it
+    tailed = "<html><body><article><p>alpha<sup></sup>beta gamma.</p></article></body></html>"
+    assert extract(tailed, output_format="markdown", config=ZERO_CONFIG) == "alphabeta gamma."
+    assert extract(tailed, output_format="markdown", favor_precision=True, config=ZERO_CONFIG) == "alphabeta gamma."
+
+
 def test_extract_with_metadata():
     """Test extract_with_metadata method"""
     url = "http://aa.bb/cc.html"

--- a/trafilatura/htmlprocessing.py
+++ b/trafilatura/htmlprocessing.py
@@ -409,6 +409,13 @@ def convert_tags(tree: HtmlElement, options: Extractor, url: str | None = None) 
         elem.set("rend", "h3")
         elem.tag = "head"
 
+    # an empty sup/sub carries nothing to raise or lower, and process_node() would later
+    # hand it the following text as its own, so the marker would wrap the wrong words.
+    # The tail is kept in every focus mode, unlike the pruning of CUT_EMPTY_ELEMS.
+    for elem in tree.iter("sub", "sup"):
+        if not elem.text and len(elem) == 0:
+            delete_element(elem)
+
     if options.formatting:
         for elem in tree.iter(REND_TAG_MAPPING.keys()):
             elem.attrib.clear()

--- a/trafilatura/xml.py
+++ b/trafilatura/xml.py
@@ -80,6 +80,11 @@ META_ATTRIBUTES = [
 ]
 
 HI_FORMATTING = {"#b": "**", "#i": "*", "#u": "__", "#t": "`"}
+# markdown has no superscript/subscript syntax, so these are emitted as inline HTML
+# (CommonMark passes it through), matching what HTML_TAG_MAPPING already emits for the
+# html output format. The pandoc-style "~15ya~" is not usable: GitHub renders a single
+# tilde as strikethrough, so it would replace one wrong meaning with another.
+HI_HTML_TAGS = {"#sup": "sup", "#sub": "sub"}
 HEADING_LEVELS = frozenset("123456")
 # preceding characters that already separate content, so no extra space/newline is needed
 SEPARATORS = frozenset((" ", "\n", "|", ""))
@@ -313,10 +318,13 @@ def _code_span(text: str) -> str:
     return f"{fence}{text}{fence}"
 
 
-def _md_wrap(text: str, marker: str) -> str:
+def _md_wrap(text: str, opening: str, closing: str | None = None) -> str:
     "Wrap text in a markdown marker, leaving any flanking whitespace outside it (valid CommonMark)."
     stripped = text.strip()
-    return text.replace(stripped, f"{marker}{stripped}{marker}", 1) if stripped else text
+    if not stripped:
+        return text
+    closing = opening if closing is None else closing
+    return text.replace(stripped, f"{opening}{stripped}{closing}", 1)
 
 
 def _md_code(text: str) -> str:
@@ -462,11 +470,15 @@ def replace_element_text(
         elif element.tag == "del":
             elem_text = _md_wrap(elem_text.replace("~~", "~\\~"), "~~")
         elif element.tag == "hi":
-            marker = HI_FORMATTING.get(element.get("rend") or "")
+            rend = element.get("rend") or ""
+            marker = HI_FORMATTING.get(rend)
             if marker == "`":
                 elem_text = _md_code(elem_text)  # inline code, flanking whitespace stays outside
             elif marker:
                 elem_text = _md_wrap(elem_text, marker)
+            elif rend in HI_HTML_TAGS:
+                tag = HI_HTML_TAGS[rend]
+                elem_text = _md_wrap(elem_text, f"<{tag}>", f"</{tag}>")
         elif element.tag == "code":
             lbs = element.xpath(".//lb")
             if "\n" in elem_text or lbs:  # Handle <br> inside <code>


### PR DESCRIPTION
Fixes #889.

- Emit `sup`/`sub` as inline HTML in Markdown so exponent and index boundaries survive:
  `100<sup>2</sup>=10000` was serialized as `1002=10000`, silently changing the number.
  `HI_FORMATTING` only holds symmetric markers, so these two never entered the branch.
- Drop an empty `<sup></sup>` during tag conversion while preserving its tail text.
  `process_node()` hands a textless element the following text as its own, so without this
  the new marker would wrap the wrong words (`a<sup></sup>b` became `a<sup>b</sup>`).
  Doing it in `convert_tags()` rather than via `CUT_EMPTY_ELEMS` keeps the tail in every
  focus mode, including `favor_precision`.
- Add regression coverage for normal, empty, whitespace-only and precision-mode inputs.

I kept inline HTML rather than the pandoc-style `^2^` / `~15ya~`: CommonMark passes raw
inline tags through, and GitHub renders a single tilde as strikethrough, so `~15ya~` would
have replaced one wrong meaning with another.

Note on reproducing: the short sample in the issue falls below `MIN_EXTRACTED_SIZE` and
enters the fallback path, which prints `100\n2\n=10000`. The regression tests use the
zero-threshold config to exercise the Markdown serializer directly; with content above the
threshold, master produces exactly the concatenation reported in #889.

Validation on this branch: `pytest` (239 passed, 3 skipped, including `realworld_tests.py`),
`ruff check .` and `mypy -p trafilatura` unchanged from master, `ruff format --check` clean.
