### PR TITLE
maintenance: select ruff rules explicitly so CI is deterministic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,14 @@ docs = [
 line-length = 127
 target-version = "py310"
 
+[tool.ruff.lint]
+# select the rule set explicitly so linting stays deterministic across ruff
+# releases, for the same reason the mypy block below pins its options one by one.
+# ruff 0.16.0 widened its default selection from 59 rules to 413, and the dev
+# extra asks for an unpinned "ruff >= 0.15", so CI turns red on code nobody
+# touched. these four codes are ruff's pre-0.16 defaults.
+select = ["E4", "E7", "E9", "F"]
+
 [tool.mypy]
 # pin the target so type-checking is deterministic across contributor machines
 # and matches CI: check against the lowest supported version on Linux


### PR DESCRIPTION
CI is currently red on every pull request, and the cause is outside the changed code.

## What happened

[ruff 0.16.0](https://astral.sh/blog/ruff-v0.16.0) (released 2026-07-25) widened its **default** rule selection from 59 rules to 413. `pyproject.toml` asks for `ruff >= 0.15` with no upper bound and does not configure `[tool.ruff.lint] select`, so CI installs whatever is newest and lints against the new defaults.

Reproduced against **unmodified `master` at 3d89493**, no other changes in the tree:

| ruff | `ruff check .` |
|---|---|
| 0.15.4 | `All checks passed!` |
| 0.16.0 | `Found 103 errors.` |

The 103 findings are spread over 31 files and come from rule families that were not previously on by default: `BLE001` (22), `I001` (18), `FURB167` (12), `UP031` (11), `SIM102` (5), plus `RUF`, `DTZ`, `S`, `PL`, `B`, `PIE`, `FLY` and `C4`. None of them are new code.

Confirming it is only the selection and nothing else in the release:

```
ruff 0.16.0, master, --select E4,E7,E9,F  ->  All checks passed!
```

## The change

One block in `pyproject.toml` selecting `E4`, `E7`, `E9`, `F` explicitly. Those are ruff's pre-0.16 defaults, so linting behaviour is unchanged from what the repository has been enforcing, and it no longer moves when ruff changes its mind about defaults.

This is the same reasoning already written down a few lines below for mypy in that file:

> `# explicit strictness — stable across mypy upgrades, unlike 'strict = true'`

Verified after the change:

```
ruff 0.15.4  ruff check .                          ->  All checks passed!
ruff 0.16.0  ruff check .                          ->  All checks passed!
ruff 0.16.0  ruff format --check trafilatura tests ->  41 files already formatted
```

`ruff format` was never affected; only the lint step was.

## Not included on purpose

Adopting any of the newly-default rules is a separate judgement call, and 103 mechanical edits do not belong in the same change as a CI repair. Roughly 43 are auto-fixable if you want them. Happy to open a follow-up per rule family, or to add an upper bound like `ruff >= 0.15, < 0.17` instead if you prefer pinning the tool over pinning the selection. Your call and I will match whatever you pick.

Found this while checking why #891 was red. That PR touches only `htmlprocessing.py`, `xml.py` and `tests/unit_tests.py` and contributes none of the 103 findings.