### PR TITLE
maintenance: run the lint step under bash so failures are not discarded on Windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,6 +53,10 @@ jobs:
       run: uv pip install --system -e ".[dev]"
 
     - name: Lint and format check
+      # bash stops at the first failing command on every runner. The default
+      # shell on Windows is pwsh, which reports only the last command's status,
+      # so a `ruff check` failure there was discarded by the `ruff format` pass.
+      shell: bash
       run: |
         ruff check .
         ruff format --check --diff trafilatura tests


### PR DESCRIPTION
On `windows-latest` the `Lint and format check` step reports success even when `ruff check` fails.

The step runs two commands in one `run:` block. With no `shell:` key GitHub uses `pwsh` on Windows, and the step's exit status is taken from `$LASTEXITCODE` of the last command only. `ruff format --check` passes, so a preceding `ruff check` failure is discarded. On Linux and macOS the same block runs under `bash -e` and stops at the first failure.

**This has already happened here.** Run [30165454624](https://github.com/adbar/trafilatura/actions/runs/30165454624) (2026-07-25, before #892): every ubuntu and macos job failed at that step, while `build (windows-latest, 3.11)` reported success. Its log reads

```
Found 103 errors.
41 files already formatted
```

**A/B check on a fork of this repo.** Same deliberate `F401` in `trafilatura/utils.py` in both arms; the only difference is the workflow.

| | `build (windows-latest, 3.11)` | the other 8 jobs |
|---|---|---|
| workflow unchanged | **pass**, 3m09s — [run 30405779646](https://github.com/igorsaevets/trafilatura/actions/runs/30405779646) | fail |
| with `shell: bash` | **fail**, 31s — [run 30405781648](https://github.com/igorsaevets/trafilatura/actions/runs/30405781648) | fail |

The 3m09s is the Windows job discarding the lint failure and going on to run the full test suite. The 31s is it stopping at the lint step, like every other runner.

`bash` ships on GitHub's Windows images, so nothing else needs to change. If you would rather not depend on that, splitting the step into two `run:` steps fixes it just as well and gives each command its own entry in the UI. Happy to redo it that way, or to close this if you would rather handle it differently.

This is latent today: with #892 merged, `ruff check .` passes on `master`. It matters the next time lint actually fails.
