### PR TITLE
fix: recover pages wrapped in a single form, and remove extraction artifacts

### DIFF
--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -1562,8 +1562,93 @@ def test_precision_discard_link_token_only():
     assert not discarded("class", "article-permalink")  # compound: no longer dropped
     assert not discarded("class", "headline-link")
     assert not discarded("class", "featured-link--wrap")
-    assert discarded("class", "article-bottom")  # 'bottom' still substring-matched
+    assert discarded("class", "article-bottom")  # 'bottom' still matched at a token boundary
     assert discarded("class", "site-header", tag="header")  # .//header still discarded
+
+
+def test_precision_discard_bottom_token_boundary():
+    "regression: PRECISION_DISCARD_XPATH must match 'bottom' only where it starts or ends a \
+    class token. As a bare substring it also matched CSS spacing utilities -- alsumaria.tv wraps \
+    the article column in 'Padding-bottom-lg-30', so precision mode discarded the whole article."
+    import trafilatura.xpaths as xp
+
+    def discarded(attr, value, tag="div"):
+        root = etree.fromstring(f'<html><body><{tag} {attr}="{value}"><p>content</p></{tag}></body></html>')
+        return any(len(x(root)) > 0 for x in xp.PRECISION_DISCARD_XPATH)
+
+    # page-bottom chrome: still discarded, whichever end of the token 'bottom' sits at
+    assert discarded("class", "bottom")
+    assert discarded("class", "article-bottom")
+    assert discarded("class", "bottom-bar")
+    assert discarded("id", "bottom")
+    assert discarded("class", "wrapper bottom")
+    # spacing/border utilities on real content: 'bottom' mid-token, must NOT be discarded
+    assert not discarded("class", "Padding-bottom-lg-30")
+    assert not discarded("class", "col-8 Padding-bottom-lg-30 floatL")
+    assert not discarded("class", "border-bottom-0")
+    assert not discarded("class", "mb-bottom-3")
+
+
+def test_wrapper_form_kept():
+    "regression: ASP.NET WebForms and similar wrap the entire page in one <form id='aspnetForm'>. \
+    tree_cleaning() deletes every form, so on those sites (alsumaria.tv) the whole document was \
+    discarded and extraction fell back to unrelated sidebar chrome. A form holding most of the \
+    text is a layout wrapper and must survive; genuine widget forms must still be removed."
+    from trafilatura.htmlprocessing import tree_cleaning
+
+    article = (
+        "<p>" + "This is the actual article body with enough text to be extracted. " * 4 + "</p>"
+    )
+    options = core.Extractor(config=ZERO_CONFIG)
+
+    # the wrapper form survives cleaning, so the content is still there to be selected --
+    # without this the whole document was gone and only the recovery path could save anything
+    wrapped = f'<html><body><form method="post" id="aspnetForm"><div>{article}</div></form></body></html>'
+    cleaned = tree_cleaning(load_html(wrapped), options)
+    assert "the actual article body" in cleaned.text_content()
+    assert cleaned.find(".//form") is None  # demoted, not left as a form
+    assert "the actual article body" in extract(wrapped, config=ZERO_CONFIG)
+
+    # a search/newsletter widget alongside real content is still removed outright
+    with_widget = (
+        f"<html><body><div>{article}</div>"
+        '<form><p>Search this site</p><input type="text"/></form>'
+        "</body></html>"
+    )
+    cleaned = tree_cleaning(load_html(with_widget), options)
+    assert "the actual article body" in cleaned.text_content()
+    assert "Search this site" not in cleaned.text_content()
+
+    # MANUALLY_CLEANED is mutated in place by users (cf. issue #746 and docs/settings.rst):
+    # taking "form" out must keep widget forms instead of raising on the internal removal
+    from trafilatura.settings import MANUALLY_CLEANED
+
+    MANUALLY_CLEANED.remove("form")
+    try:
+        cleaned = tree_cleaning(load_html(with_widget), options)
+        assert "Search this site" in cleaned.text_content()
+    finally:
+        MANUALLY_CLEANED.insert(5, "form")
+    assert "form" in MANUALLY_CLEANED
+
+
+def test_no_duplicate_paragraph_from_lb_tail():
+    "regression: handle_other_elements() emits a text-bearing div whole and appending it MOVES it \
+    into result_body, but _extract() iterates a subelems list captured beforehand -- so an <lb> \
+    inside that div was visited again and re-emitted its tail, duplicating a paragraph \
+    (alsumaria.tv). Whitespace-only <lb> tails left by pruned ad slots must not become blank lines."
+    html = (
+        "<html><body><article><div>"
+        "First paragraph of the article, long enough to be kept by the extractor.<br/>"
+        '        <div class="advert">        </div>        <br/>'
+        "Second paragraph of the article, also long enough to be kept here."
+        "</div></article></body></html>"
+    )
+    result = extract(html, config=ZERO_CONFIG)
+    assert result.count("Second paragraph of the article") == 1
+    assert "First paragraph of the article" in result
+    # no blank, space-filled lines from the pruned block's indentation
+    assert not any(line and line.isspace() for line in result.split("\n"))
 
 
 def test_body_xpath_fulltext_class():

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -1596,9 +1596,7 @@ def test_wrapper_form_kept():
     text is a layout wrapper and must survive; genuine widget forms must still be removed."
     from trafilatura.htmlprocessing import tree_cleaning
 
-    article = (
-        "<p>" + "This is the actual article body with enough text to be extracted. " * 4 + "</p>"
-    )
+    article = "<p>" + "This is the actual article body with enough text to be extracted. " * 4 + "</p>"
     options = core.Extractor(config=ZERO_CONFIG)
 
     # the wrapper form survives cleaning, so the content is still there to be selected --
@@ -1610,11 +1608,7 @@ def test_wrapper_form_kept():
     assert "the actual article body" in extract(wrapped, config=ZERO_CONFIG)
 
     # a search/newsletter widget alongside real content is still removed outright
-    with_widget = (
-        f"<html><body><div>{article}</div>"
-        '<form><p>Search this site</p><input type="text"/></form>'
-        "</body></html>"
-    )
+    with_widget = f'<html><body><div>{article}</div><form><p>Search this site</p><input type="text"/></form></body></html>'
     cleaned = tree_cleaning(load_html(with_widget), options)
     assert "the actual article body" in cleaned.text_content()
     assert "Search this site" not in cleaned.text_content()

--- a/trafilatura/htmlprocessing.py
+++ b/trafilatura/htmlprocessing.py
@@ -44,10 +44,36 @@ PRESERVE_IMG_CLEANING = {"figure", "picture", "source"}
 CODE_INDICATORS = ["{", '("', "('", "\n    "]
 
 
+def _handle_forms(tree: HtmlElement) -> None:
+    """Delete <form> elements, keeping those that wrap the page's main content.
+
+    Frameworks like ASP.NET WebForms put the whole document inside a single
+    <form id="aspnetForm">, so dropping every form leaves nothing to extract.
+    A form holding most of the remaining text is such a layout wrapper and gets
+    demoted to a plain container; genuine widgets (search, login, newsletter)
+    hold little text and are still removed.
+    """
+    forms = list(tree.iter("form"))
+    if not forms:
+        return
+    # run after the other elements are gone, so script/head text cannot skew the ratio
+    total = len(tree.text_content())
+    for form in forms:
+        if total and len(form.text_content()) > total / 2:
+            form.tag = "div"
+        else:
+            delete_element(form)
+
+
 def tree_cleaning(tree: HtmlElement, options: Extractor) -> HtmlElement:
     "Prune the tree by discarding unwanted elements."
     # determine cleaning strategy, use lists to keep it deterministic
     cleaning_list, stripping_list = MANUALLY_CLEANED.copy(), MANUALLY_STRIPPED.copy()
+    # forms are handled separately below, once the rest of the noise is gone. MANUALLY_CLEANED is
+    # public API users mutate in place, so honour a removed "form" instead of assuming it is there.
+    clean_forms = "form" in cleaning_list
+    if clean_forms:
+        cleaning_list.remove("form")
     if not options.tables:
         cleaning_list.extend(["table", "td", "th", "tr"])
     else:
@@ -78,6 +104,9 @@ def tree_cleaning(tree: HtmlElement, options: Extractor) -> HtmlElement:
         for expression in cleaning_list:
             for element in tree.iter(expression):
                 delete_element(element)
+
+    if clean_forms:
+        _handle_forms(tree)
 
     return prune_html(tree, options.focus)
 

--- a/trafilatura/main_extractor.py
+++ b/trafilatura/main_extractor.py
@@ -21,7 +21,7 @@ from .htmlprocessing import (
     prune_unwanted_nodes,
 )
 from .settings import DEDUPE_SCAN_CAP, INLINE_CARRIED, MIN_DUPLICATE_LENGTH, TAG_CATALOG, Extractor
-from .utils import FORMATTING_PROTECTED, is_image_file, text_chars_test, trim
+from .utils import FORMATTING_PROTECTED, SPACING_PROTECTED, is_image_file, text_chars_test, trim
 from .xml import delete_element
 from .xpaths import (
     BODY_XPATH,
@@ -392,7 +392,10 @@ def handle_paragraphs(element: _Element, potential_tags: set[str], options: Extr
         if last_elem.tag == "lb" and last_elem.tail is None:
             delete_element(last_elem)
         return processed_element
-    if processed_element.text:
+    # text_chars_test, not truthiness: layout wrappers (clearfix/spacer divs, cleared-out
+    # ad slots) leave indentation-only text, which used to be emitted as blank paragraphs
+    # and, sitting between two copies of a paragraph, also defeated the adjacent dedup
+    if text_chars_test(processed_element.text):
         return processed_element
     _log_event("discarding element:", "p", tostring(processed_element))
     return None
@@ -778,7 +781,17 @@ def _extract(tree: HtmlElement, options: Extractor) -> tuple[_Element, str, set[
         if {e.tag for e in subelems} == {"lb"}:
             subelems = [subtree]
         # extract content
-        result_body.extend([el for el in (handle_textelem(e, potential_tags, options) for e in subelems) if el is not None])
+        for elem in subelems:
+            # handle_other_elements() emits a text-bearing div as-is, children and all, and
+            # appending it MOVES it into result_body. Its descendants are still in the list
+            # captured above, so revisiting one would emit its text twice -- an <lb> whose tail
+            # carries a paragraph turned into a duplicate of that paragraph. handle_paragraphs()
+            # marks the children it consumes "done"; this covers the elements it cannot retag.
+            if elem.getroottree().getroot() is result_body:
+                continue
+            processed_elem = handle_textelem(elem, potential_tags, options)
+            if processed_elem is not None:
+                result_body.append(processed_elem)
         # remove trailing titles
         while len(result_body) > 0 and (result_body[-1].tag in NOT_AT_THE_END):
             delete_element(result_body[-1], keep_tail=False)
@@ -816,6 +829,17 @@ def extract_content(cleaned_tree: HtmlElement, options: Extractor) -> tuple[_Ele
     # filter output
     strip_elements(result_body, "done")
     strip_tags(result_body, "div")
+    # stripping the divs above merges their indentation into the preceding <lb>'s tail, so an
+    # <lb> that only separated pruned blocks (ad slots, clearfix spacers) ends up carrying a
+    # run of whitespace -- rendered verbatim as blank, space-filled lines in txt/markdown.
+    # Inside code/pre that whitespace is the indentation itself, so leave those alone.
+    for linebreak in result_body.iter("lb"):
+        if (
+            linebreak.tail
+            and not text_chars_test(linebreak.tail)
+            and not any(anc.tag in SPACING_PROTECTED for anc in linebreak.iterancestors())
+        ):
+            linebreak.tail = None
     # return
     return result_body, temp_text, len(temp_text)
 

--- a/trafilatura/xpaths.py
+++ b/trafilatura/xpaths.py
@@ -290,11 +290,15 @@ TEASER_DISCARD_XPATH = [
 PRECISION_DISCARD_XPATH = [
     XPath(""".//header"""),
     # 'link' matched as a whole class token, not a substring (that dropped permalink/headline-link/
-    # etc.); still drops class="link" (guarded by test_precision_recall). 'bottom'/'border' = substrings.
+    # etc.); still drops class="link" (guarded by test_precision_recall). 'border' = substring.
+    # 'bottom' must start or end a token: page-bottom chrome is named 'bottom'/'bottom-bar'/
+    # 'article-bottom', whereas a mid-token 'bottom' is a CSS spacing utility
+    # ('Padding-bottom-lg-30', 'border-bottom-0') that layout wrappers put on real content.
     XPath(
         r"""
     .//*[self::div or self::item or self::list or self::p or self::section or self::span][
-    contains(@id|@class, 'bottom') or re:test(@id|@class, '(^|\s)link(\s|$)') or contains(@style, 'border')]
+    re:test(@id|@class, '(^|\s)bottom|bottom(\s|$)') or re:test(@id|@class, '(^|\s)link(\s|$)') or
+    contains(@style, 'border')]
     """,
         namespaces={"re": regexpNS},
     ),


### PR DESCRIPTION
## Problem

On [alsumaria.tv](https://www.alsumaria.tv/), an Arabic news site, extraction returns an unrelated sidebar video caption instead of the article. In precision mode that caption is the *only* output:

```console
$ trafilatura -u "https://www.alsumaria.tv/news/international/572277/..." --formatting --markdown --precision
الأربعين الحسيني .. دروس التضحية ومسيرة الإصلاح - عشرين م٥ - الحلقة ٥٤ | الموسم 5
```

Tracing it turned up four independent causes. Each reproduces on its own, and two are not site-specific — any page with `<br>`-separated text in a `div` and an inline ad block hits them.

## Causes and fixes

**1. A single wrapping `<form>` discards the whole document.** `tree_cleaning()` deletes every `<form>`. ASP.NET WebForms puts the entire page inside one `<form id="aspnetForm">`, so nothing was left but the chrome outside it, which is what got extracted.

A form holding most of the remaining text is a layout wrapper, not a widget, and is now demoted to a plain container. Genuine widget forms (search, login, newsletter) hold little text and are still removed. Forms are handled after the other noise is gone, so `<script>` and `<head>` text cannot skew the comparison.

`MANUALLY_CLEANED` keeps `"form"`, so the documented list still reflects that forms are removed. Since that list is public API users mutate in place (`docs/settings.rst`, #746), an in-place removal of `"form"` is now honoured rather than raising.

**2. `'bottom'` matched CSS spacing utilities.** `PRECISION_DISCARD_XPATH` matched `bottom` as a bare substring. The article column carries `Padding-bottom-lg-30`, so precision mode discarded the article itself. `bottom` now has to start or end a class token — the same tightening already applied to `'link'`. Page-bottom chrome (`bottom`, `bottom-bar`, `article-bottom`) is still discarded; `Padding-bottom-lg-30` and `border-bottom-0` are not.

**3. A paragraph was emitted twice.** `handle_other_elements()` emits a text-bearing `div` whole, and appending it *moves* it into `result_body` — but `_extract()` iterates a `subelems` list captured beforehand, so an `<lb>` inside that div was visited again and re-emitted its tail as a second paragraph. Elements already moved into `result_body` are now skipped. `handle_paragraphs()` marks the children it consumes `"done"`; this covers the ones it cannot retag.

**4. Blank, space-filled lines.** `handle_paragraphs()` treated whitespace-only text as content (plain truthiness), and stripping divs merges their indentation into the preceding `<lb>`'s tail — so pruned ad slots and clearfix spacers surfaced as lines of spaces. Both are now dropped, leaving `code` and `pre` untouched, where that whitespace is the indentation itself.

## Result

```console
$ trafilatura -u "https://www.alsumaria.tv/news/international/572277/..." --formatting --markdown --precision
## أعلن الجيش الإسرائيلي، اليوم الأربعاء، بدء هجمات قال إنها "مركزة" في جنوب لبنان، عقب إصدار إنذار بإخلاء بلدة المنصوري، متهماً حزب الله بخرق اتفاق وقف إطلاق النار.

وقال الجيش الإسرائيلي، في بيان، إنه وجّه إنذاراً إلى سكان بلدة المنصوري في جنوب لبنان بالإخلاء، مدعياً أن حزب الله خرق اتفاق وقف إطلاق النار، وأن قواته "ستعمل ضده بقوة".

وأضاف الجيش الإسرائيلي أنه بدأ تنفيذ "هجمات مركزة" في جنوب لبنان، مؤكداً أن هذه العمليات تأتي رداً على ما وصفه بـ"خرق حزب الله لوقف إطلاق النار".
```

Title, author, date and categories also come out correctly with `--with-metadata`.

## Testing

- Three new regression tests, each verified to fail on `master` and pass with the fix: `test_precision_discard_bottom_token_boundary`, `test_wrapper_form_kept`, `test_no_duplicate_paragraph_from_lb_tail`. The form test also covers the `MANUALLY_CLEANED` in-place override.
- Full suite passes (278 tests), `ruff` and `mypy` clean.
- Scored the eval corpus with the chunk metric from `tests/evaluate.py`: default, fast and recall modes are unchanged; precision mode gains one true negative.

| variant | before (P / R / F1) | after (P / R / F1) |
|---|---|---|
| trafilatura | 0.9140 / 0.9480 / 0.9307 | 0.9140 / 0.9480 / 0.9307 |
| trafilatura fast | 0.9081 / 0.9182 / 0.9131 | 0.9081 / 0.9182 / 0.9131 |
| trafilatura precision | 0.9104 / 0.9071 / 0.9088 | **0.9139** / 0.9071 / **0.9104** |
| trafilatura recall | 0.8975 / 0.9442 / 0.9203 | 0.8975 / 0.9442 / 0.9203 |

_I used Claude Opus for coding_
