### PR TITLE
fix: keep document listings when pruning link farms

### DIFF
--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -1503,6 +1503,31 @@ def test_link_density_whole_card_links_kept():
     assert trafilatura.htmlprocessing.link_density_test(element, text)[0] is False  # long links -> content, kept
 
 
+def test_link_density_paragraph_listing_kept():
+    "regression (#900): a document listing carries one short link per paragraph, which the #584 \
+    branch read as a farm because the only exemption was on average link length. Pruning it \
+    dropped the rest of the article with it, since the outermost matching div goes as a whole."
+    from trafilatura.utils import trim
+
+    items = "".join(f'<p><ref target="/d{i}.pdf">Instruktionsbok MC 258 part {i}</ref></p>' for i in range(14))
+    element = html.fromstring(f"<body><div>{items}</div><p>real article sibling here</p></body>")[0]
+    text = trim(element.text_content())
+    assert len(text) > 300  # large, >4 short links, >90% link text: trips every other #584 gate
+    assert trafilatura.htmlprocessing.link_density_test(element, text)[0] is False
+
+
+def test_link_density_links_sharing_a_paragraph_pruned():
+    "the #900 exemption asks for one link per paragraph, so a farm that merely sits inside a \
+    paragraph is still pruned: wrapping 20 headlines in a single <p> must not buy an exemption."
+    from trafilatura.utils import trim
+
+    items = "".join(f'<ref target="/n{i}">Latest news headline number {i} about some topic today</ref> ' for i in range(20))
+    element = html.fromstring(f"<body><div><p>{items}</p></div><p>real article sibling here</p></body>")[0]
+    text = trim(element.text_content())
+    assert len(text) > 300
+    assert trafilatura.htmlprocessing.link_density_test(element, text)[0] is True
+
+
 def test_overall_discard_legacy_tokens():
     "regression on the legacy single-PR discard tokens, each decided by a full-WMB single-token A/B \
     (see xpaths.py audit note): 'yin' STAYS (net-positive despite English '-ying'/'y+Info' \

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -1528,6 +1528,19 @@ def test_link_density_links_sharing_a_paragraph_pruned():
     assert trafilatura.htmlprocessing.link_density_test(element, text)[0] is True
 
 
+def test_link_density_listing_with_one_shared_paragraph_pruned():
+    "the exemption is all-or-nothing on purpose: one paragraph holding two links makes the \
+    container a farm again, which is what lets the check work without a ratio or a threshold."
+    from trafilatura.utils import trim
+
+    items = "".join(f'<p><ref target="/d{i}.pdf">Instruktionsbok MC 258 part {i}</ref></p>' for i in range(14))
+    shared = '<p><ref target="/a">Also see this page</ref> <ref target="/b">and this other one</ref></p>'
+    element = html.fromstring(f"<body><div>{items}{shared}</div><p>real article sibling here</p></body>")[0]
+    text = trim(element.text_content())
+    assert len(text) > 300
+    assert trafilatura.htmlprocessing.link_density_test(element, text)[0] is True
+
+
 def test_overall_discard_legacy_tokens():
     "regression on the legacy single-PR discard tokens, each decided by a full-WMB single-token A/B \
     (see xpaths.py audit note): 'yin' STAYS (net-positive despite English '-ying'/'y+Info' \

--- a/trafilatura/htmlprocessing.py
+++ b/trafilatura/htmlprocessing.py
@@ -124,13 +124,12 @@ def collect_link_info(
 
 
 def is_paragraph_listing(links_xpath: list[HtmlElement]) -> bool:
-    "Tell a document listing (each link its own paragraph) from a farm (links running together)"
-    own_paragraph = 0
+    "Tell a document listing (every link alone in its paragraph) from a farm (links running together)"
     for link in links_xpath:
         parent = link.getparent()
-        if parent is not None and parent.tag == "p" and len(parent.findall(".//ref")) == 1:
-            own_paragraph += 1
-    return own_paragraph * 2 > len(links_xpath)
+        if parent is None or parent.tag != "p" or len(parent.findall(".//ref")) > 1:
+            return False
+    return True
 
 
 def link_density_test(element: HtmlElement, text: str, favor_precision: bool = False) -> tuple[bool, list[str]]:

--- a/trafilatura/htmlprocessing.py
+++ b/trafilatura/htmlprocessing.py
@@ -123,6 +123,16 @@ def collect_link_info(
     return sum(lengths), len(mylist), shortelems, mylist
 
 
+def is_paragraph_listing(links_xpath: list[HtmlElement]) -> bool:
+    "Tell a document listing (each link its own paragraph) from a farm (links running together)"
+    own_paragraph = 0
+    for link in links_xpath:
+        parent = link.getparent()
+        if parent is not None and parent.tag == "p" and len(parent.findall(".//ref")) == 1:
+            own_paragraph += 1
+    return own_paragraph * 2 > len(links_xpath)
+
+
 def link_density_test(element: HtmlElement, text: str, favor_precision: bool = False) -> tuple[bool, list[str]]:
     "Remove sections which are rich in links (probably boilerplate)"
     links_xpath = element.findall(".//ref")
@@ -167,7 +177,7 @@ def link_density_test(element: HtmlElement, text: str, favor_precision: bool = F
         # local vars: leave mylist [] on fall-through so the caller's backtracking gate is unaffected
         linklen, elemnum, _, farmlist = collect_link_info(links_xpath)
         # avg link len >= 100 => catalog/listing content (one link per card), not a farm: keep it
-        if linklen > len(text) * LINK_FARM_RATIO and linklen < 100 * elemnum:
+        if linklen > len(text) * LINK_FARM_RATIO and linklen < 100 * elemnum and not is_paragraph_listing(links_xpath):
             return True, farmlist
     return False, mylist
 


### PR DESCRIPTION
On the page in #900, `extract()` returns only the first content block: 873 characters against 1633 on 2.1.0.

The cause is the link farm branch added in #887 (`link_density_test`, `htmlprocessing.py`). It treats a large, link-dense element as boilerplate unless the average link text reaches 100 characters. The reporter's page is a listing of PDF manuals with one short title per link, so it never clears that exemption: the container holds 63 links and 1715 of its 1844 characters are link text, averaging 27.2 characters. `prune_unwanted_sections` calls `delete_by_link_density(tree, "div", backtracking=True)`, which walks every div in document order, so the outermost match is dropped with its whole subtree and the rest of the article goes with it.

Average link length cannot separate the two cases on its own, because a nav sidebar and a document listing both use short link text. The markup differs instead: a farm runs its links together inside the container, while a listing gives each link its own paragraph. `is_paragraph_listing` tests for that shape and exempts the element when more than half of its links stand alone in a paragraph. Links that share a paragraph do not count, so wrapping a farm in a `p` element buys no exemption.

Verification:

- `test_link_density_paragraph_listing_kept` fails on master and passes on this branch; `test_link_density_links_sharing_a_paragraph_pruned` pins the other side of the exemption and passes on both.
- The reporter's page goes from 873 to 1631 characters, matching 2.1.0 output. Both link farm tests from #887 still pass.
- `unit_tests.py`, `realworld_tests.py`, `filters_tests.py`, `metadata_tests.py`, `baseline_tests.py` and `xml_tei_tests.py`: 234 passed, 3 skipped. `ruff check .` and `ruff format --check --diff trafilatura tests` are clean.
- Precision and recall over `evaldata.json` for the 100 pages present in `tests/cache` are identical before and after (P 0.908, R 0.918, F1 0.913), so the pruning trade-off does not move outside the reported case. I did not run `mypy` or the docs tests against the full extras, so those are unverified here.

Fixes #900
