### PR TITLE
fix: recover LaTeX from MathML so formulas are not silently dropped

### DIFF
--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -3254,6 +3254,50 @@ def test_math_conversion():
     assert "`k` then $t$ end" in xml.xmltotxt(tree, include_formatting=True)
 
 
+def test_math_recovery():
+    "MathML is replaced by its LaTeX source instead of being discarded with the <math> subtree."
+    options = core.Extractor()
+    options.tables = True
+
+    def clean(html_string):
+        return etree.tostring(
+            trafilatura.htmlprocessing.tree_cleaning(html.fromstring(html_string), options),
+            encoding="unicode",
+        )
+
+    # the annotation holds the original LaTeX and takes precedence over alttext
+    result = clean(
+        '<html><body><p>a <math alttext="rendered"><semantics>'
+        '<annotation encoding="application/x-tex">x^2</annotation>'
+        "</semantics></math> b</p></body></html>"
+    )
+    assert "\\(x^2\\)" in result and "rendered" not in result
+    # alttext is used when there is no LaTeX annotation
+    assert "\\(y_1\\)" in clean('<html><body><p>a <math alttext="y_1"><mi>y</mi></math> b</p></body></html>')
+    # display="block" yields block delimiters
+    assert "\\[z\\]" in clean('<html><body><p><math display="block" alttext="z"><mi>z</mi></math></p></body></html>')
+    # nothing to recover: unchanged behaviour, the element is dropped
+    result = clean("<html><body><p>a <math><mi>q</mi></math> b</p></body></html>")
+    assert "math" not in result and "q" not in result
+    # the tail of the formula survives alongside the recovered source
+    assert "\\(u\\) tail" in clean('<html><body><p><math alttext="u"><mi>u</mi></math> tail</p></body></html>')
+    # a formula in a table cell is no longer silently emptied
+    result = clean(
+        "<html><body><table><tr><td>name</td>"
+        '<td><math alttext="1.33\\times 10^{-4}"><mi>v</mi></math></td></tr></table></body></html>'
+    )
+    assert "1.33\\times 10^{-4}" in result
+
+    # end to end: Markdown output renders the recovered formula as $...$
+    doc = (
+        "<html><body><article><p>Some introductory prose that is long enough to be retained here.</p>"
+        '<p>The error was <math alttext="1.33\\times 10^{-4}"><semantics>'
+        '<annotation encoding="application/x-tex">1.33\\times 10^{-4}</annotation>'
+        "</semantics></math> overall.</p></article></body></html>"
+    )
+    assert "$1.33\\times 10^{-4}$" in extract(doc, output_format="markdown", config=ZERO_CONFIG)
+
+
 def test_inline_edge_cases():
     "Cover lb in inline context, structural-tag fallback, and redundant emphasis collapse."
     # <lb/> inside an inline element (hi) renders as a newline

--- a/trafilatura/htmlprocessing.py
+++ b/trafilatura/htmlprocessing.py
@@ -43,6 +43,25 @@ PRESERVE_IMG_CLEANING = {"figure", "picture", "source"}
 
 CODE_INDICATORS = ["{", '("', "('", "\n    "]
 
+# LaTeX source carried by MathML, in order of preference: the annotation holds the
+# original markup, alttext a rendering of it. local-name() also matches XHTML pages
+# where the subtree keeps its MathML namespace.
+TEX_ANNOTATION_XPATH = XPath('.//*[local-name()="annotation"][@encoding="application/x-tex"]')
+
+
+def recover_math(tree: HtmlElement) -> HtmlElement:
+    "Turn MathML into its LaTeX source so formulas survive the cleaning of <math>."
+    for element in tree.iter("math"):
+        annotation = TEX_ANNOTATION_XPATH(element)
+        latex = trim(annotation[0].text or "") if annotation else trim(element.get("alttext") or "")
+        if not latex:
+            continue
+        # delimiters the Markdown converter understands, see _convert_math()
+        opening, closing = ("\\[", "\\]") if element.get("display") == "block" else ("\\(", "\\)")
+        # the tail is kept when the element is deleted further down, the subtree is not
+        element.tail = f"{opening}{latex}{closing}{element.tail or ''}"
+    return tree
+
 
 def _handle_forms(tree: HtmlElement) -> None:
     """Delete <form> elements, keeping those that wrap the page's main content.
@@ -67,6 +86,8 @@ def _handle_forms(tree: HtmlElement) -> None:
 
 def tree_cleaning(tree: HtmlElement, options: Extractor) -> HtmlElement:
     "Prune the tree by discarding unwanted elements."
+    # salvage formulas before <math> is discarded along with its subtree
+    recover_math(tree)
     # determine cleaning strategy, use lists to keep it deterministic
     cleaning_list, stripping_list = MANUALLY_CLEANED.copy(), MANUALLY_STRIPPED.copy()
     # forms are handled separately below, once the rest of the noise is gone. MANUALLY_CLEANED is


### PR DESCRIPTION
Closes #792.

`<math>` is cleaned along with its whole subtree, so a formula leaves no trace in the output. When it sits in a table cell the loss is silent: the row and column structure survives and only the MathML cells come back empty, so the result reads as "no value was given" rather than as a failed extraction.

### Approach

`recover_math()` runs at the top of `tree_cleaning()`, before `<math>` is discarded. For each element it takes the LaTeX from `<annotation encoding="application/x-tex">` if present, otherwise from `alttext`, and writes it into the element's tail wrapped in `\(...\)`, or `\[...\]` when `display="block"`. The tail survives when the element is deleted, the subtree does not. `_convert_math()` already turns those delimiters into `$...$` for Markdown, so nothing downstream changes.

The annotation is preferred because it holds the original markup, while `alttext` is a rendering of it. `local-name()` in the XPath also matches XHTML pages where the subtree keeps its MathML namespace. When neither source is present nothing is recovered and behaviour is unchanged.

### Result

The example from the issue:

```
| Function | Error | Shape |
|---|---|---|
| Jacobian elliptic | $1.33\times 10^{-4}$ | [2,2,1] |
| Incomplete elliptic | $1.24\times 10^{-3}$ | [2,3,1] |
```

previously the two `Error` cells were empty.

On a real LaTeXML page (arXiv 2404.19756v5) the results table has 112 `<td>`, 69 of which contain `<math>`; all 69 were empty before. Every `<math>` on that page carries `alttext` and 864 of 865 also carry the x-tex annotation, so the source is available in practice.

### Verification

On `2ba8f62`, Python 3.12, `.[all]` installed:

- `pytest` — 334 passed, 1 skipped
- `ruff check .` — all checks passed; `ruff format --check --diff trafilatura tests` — 42 files already formatted
- `mypy -p trafilatura` — one pre-existing error in `utils.py:56`, byte-identical with and without this change
- `tests/eval_gate.py` — `fast: F1=0.9184`, `fallback: F1=0.9243`, identical with and without this change

Pages without `<math>` produce byte-identical output.

`test_math_recovery` in `tests/unit_tests.py` covers annotation precedence over `alttext`, the `alttext` fallback, block delimiters, the no-source case, tail preservation, the table cell, and the Markdown output end to end.

### One open question

Wikipedia wraps its MathML in `<span style="display: none;">`, so it is pruned as hidden content before any of this applies and stays lost. Exempting hidden MathML wrappers felt like a separate judgement call about hidden content in general, so it is not included here. Happy to add it if you would rather it were handled.
