### PR TITLE
Preserve requested structure in fallback extraction

### DIFF
--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -3,6 +3,7 @@
 Unit tests for the trafilatura library.
 """
 
+import json
 import logging
 import sys
 import time
@@ -2215,6 +2216,61 @@ def test_include_images_does_not_truncate():
     result = extract(doc, output_format="txt", include_images=True, config=real_config) or ""
     assert "/lead.jpg" in result
     assert all(f"Continuation paragraph {i}" in result for i in range(1, 5))
+
+
+def test_short_document_fallback_preserves_image():
+    """A text-only fallback must not erase a requested image when it recovers no text."""
+    first = (
+        "Some reasonably long paragraph of body text that trafilatura will keep because it "
+        "is clearly the main content of this document and not navigation furniture."
+    )
+    second = "A second paragraph that follows the figure and continues the argument at length."
+    doc = (
+        f"<html><body><article><p>{first}</p>"
+        '<img src="https://cdn.test/a.png" alt="a chart"/>'
+        f"<p>{second}</p></article></body></html>"
+    )
+    result = extract(doc, output_format="xml", include_images=True, include_links=True, config=use_config()) or ""
+    assert '<graphic src="https://cdn.test/a.png" alt="a chart"/>' in result
+
+
+def test_short_document_fallback_preserves_link():
+    """A text-only fallback must not erase a requested link when it recovers no text."""
+    paragraph = (
+        "Some reasonably long paragraph of body text that trafilatura will keep because it "
+        "is clearly the main content of this document and not navigation furniture."
+    )
+    doc = (
+        "<html><body><article><h1>Reference</h1>"
+        f'<p>{paragraph} <a href="https://example.test/source">primary source</a>.</p>'
+        "</article></body></html>"
+    )
+    result = extract(doc, output_format="xml", include_links=True, config=use_config()) or ""
+    assert '<ref target="https://example.test/source">primary source</ref>' in result
+
+
+def test_short_document_fallback_preserves_markdown_structure():
+    """Regression #896: a fallback must not flatten a valid short structured result."""
+    body = (
+        "This municipal notice is short but perfectly valid static content that a reader would expect to keep its structure. "
+    ) * 2
+    doc = f"<html><body><article><h1>Notice Title</h1><p>{body}</p></article></body></html>"
+    result = extract(doc, output_format="markdown", include_formatting=True, config=use_config()) or ""
+    assert result.startswith("# Notice Title\n\nThis municipal notice")
+
+
+def test_longer_fallback_can_replace_requested_structure():
+    """A real content recovery still wins even when its source cannot preserve an image."""
+    recovered = "Recovered canonical article body with meaningful information and complete sentences. " * 12
+    payload = json.dumps({"@type": "Article", "articleBody": recovered})
+    doc = (
+        f'<html><head><script type="application/ld+json">{payload}</script></head><body><article>'
+        '<p>A short visible article paragraph below the extraction threshold.</p><img src="chart.png" alt="chart"/>'
+        "</article></body></html>"
+    )
+    result = extract(doc, output_format="xml", include_images=True, config=use_config()) or ""
+    assert "Recovered canonical article body" in result
+    assert "<graphic" not in result
 
 
 def test_no_duplicate_content():

--- a/trafilatura/core.py
+++ b/trafilatura/core.py
@@ -17,7 +17,7 @@ from lxml.html import HtmlElement
 # own
 from .baseline import baseline, html2txt
 from .deduplication import content_fingerprint, duplicate_test
-from .external import compare_extraction, justext_rescue
+from .external import _prefer_fallback, compare_extraction, justext_rescue
 from .htmlprocessing import (
     build_html_output,
     convert_tags,
@@ -232,9 +232,11 @@ def trafilatura_sequence(
 
     # 3. rescue: baseline on the original tree
     if len_text < options.min_extracted_size and options.focus != "precision":
-        postbody, temp_text, len_text = baseline(tree)  # baseline copies element inputs
-        LOGGER.debug("non-clean extracted length: %s (extraction)", len_text)
-        forum_posts = None  # the dump saw the whole page: missing posts are boilerplate, not lost
+        b_body, b_text, b_len = baseline(tree)  # baseline copies element inputs
+        if _prefer_fallback(postbody, len_text, b_body, b_len, options):
+            postbody, temp_text, len_text = b_body, b_text, b_len
+            forum_posts = None  # the dump saw the whole page: missing posts are boilerplate, not lost
+        LOGGER.debug("non-clean extracted length: %s (extraction)", b_len)
 
     # 4. recall escalation: a short extraction covering little of the page suggests
     # under-extraction (non-article layout) — retry in recall mode, keep if clearly bigger.

--- a/trafilatura/external.py
+++ b/trafilatura/external.py
@@ -4,6 +4,8 @@ Functions grounding on third-party software.
 """
 
 import logging
+from collections import Counter
+from copy import copy
 from typing import Any
 
 # third-party
@@ -30,6 +32,41 @@ SANITIZED_XPATH = ".//aside|.//audio|.//button|.//fencedframe|.//fieldset|.//fig
 # adopt justext only when the text it replaces is at most this much longer (swept 2-4: every
 # (3, 4]-band page was justext wrongly replacing a longer, closer-to-target extraction)
 JUSTEXT_OVERRIDE_RATIO = 3
+
+# structures whose preservation callers request explicitly. Paragraph/list boundaries are
+# formatting in serialized outputs even though they do not carry a rend attribute themselves.
+_FORMATTING_TAGS = {"code", "del", "head", "hi", "item", "lb", "list", "p", "quote"}
+
+
+def _requested_structure(body: _Element, options: Extractor) -> Counter[str]:
+    """Count the structures which callers explicitly requested."""
+    protected_tags = set(_FORMATTING_TAGS) if options.formatting else set()
+    if options.links:
+        protected_tags.add("ref")
+    if options.images:
+        protected_tags.add("graphic")
+    if not protected_tags:
+        return Counter()
+    return Counter(element.tag for element in body.iter(*protected_tags))
+
+
+def _prefer_fallback(
+    body: _Element,
+    len_text: int,
+    candidate_body: _Element,
+    candidate_len: int,
+    options: Extractor,
+) -> bool:
+    """Accept a fallback unless it loses requested structure without recovering text."""
+    if candidate_len > len_text:
+        return True
+
+    current = _requested_structure(body, options)
+    if not current:
+        return True
+
+    candidate = _requested_structure(candidate_body, options)
+    return all(candidate[tag] >= count for tag, count in current.items())
 
 
 def try_readability(htmlinput: HtmlElement) -> HtmlElement:
@@ -100,6 +137,11 @@ def compare_extraction(
     LOGGER.debug("extracted length: %s (algorithm) %s (extraction)", len_algo, len_text)
 
     use_readability = _prefer_readability(body, temppost_algo, algo_text, len_text, len_algo, options)
+    if use_readability and _requested_structure(body, options):
+        # Compare the representation that would actually be returned. The raw readability
+        # tree still uses HTML tags (img/a/h1), while the main extractor uses graphic/ref/head.
+        structured_body, _, structured_len = sanitize_tree(copy(temppost_algo), options)
+        use_readability = _prefer_fallback(body, len_text, structured_body, structured_len, options)
     if use_readability:
         body, text, len_text = temppost_algo, algo_text, len_algo
     LOGGER.debug("using %s extraction: %s", "generic" if use_readability else "custom", options.source)
@@ -109,7 +151,11 @@ def compare_extraction(
         LOGGER.debug("unclean document triggering justext examination: %s", options.source)
         body2, text2, len_text2 = justext_rescue(cleaned_tree, options)
         # prevent too short documents from replacing the main text
-        if text2 and len_text <= JUSTEXT_OVERRIDE_RATIO * len_text2:
+        if (
+            text2
+            and len_text <= JUSTEXT_OVERRIDE_RATIO * len_text2
+            and _prefer_fallback(body, len_text, body2, len_text2, options)
+        ):
             LOGGER.debug("using justext, length: %s", len_text2)
             body, text, len_text = body2, text2, len_text2
             jt_result = True

--- a/trafilatura/external.py
+++ b/trafilatura/external.py
@@ -5,7 +5,6 @@ Functions grounding on third-party software.
 
 import logging
 from collections import Counter
-from copy import copy
 from typing import Any
 
 # third-party
@@ -18,7 +17,7 @@ from lxml.html import HtmlElement
 from .baseline import basic_cleaning
 from .htmlprocessing import convert_tags, prune_unwanted_nodes, tree_cleaning
 from .readability_lxml import Document as ReadabilityDocument  # fork
-from .settings import JUSTEXT_LANGUAGES, Extractor
+from .settings import JUSTEXT_LANGUAGES, TAG_CATALOG, Extractor
 from .utils import fromstring_bytes, trim
 from .xml import TEI_VALID_TAGS
 from .xpaths import OVERALL_DISCARD_XPATH
@@ -33,9 +32,9 @@ SANITIZED_XPATH = ".//aside|.//audio|.//button|.//fencedframe|.//fieldset|.//fig
 # (3, 4]-band page was justext wrongly replacing a longer, closer-to-target extraction)
 JUSTEXT_OVERRIDE_RATIO = 3
 
-# structures whose preservation callers request explicitly. Paragraph/list boundaries are
-# formatting in serialized outputs even though they do not carry a rend attribute themselves.
-_FORMATTING_TAGS = {"code", "del", "head", "hi", "item", "lb", "list", "p", "quote"}
+# Extraction converts blockquote/pre to quote and list children to item. The remaining
+# catalog tags are the formatting structures that can occur in the output tree.
+_FORMATTING_TAGS = (TAG_CATALOG - {"blockquote", "pre"}) | {"item"}
 
 
 def _requested_structure(body: _Element, options: Extractor) -> Counter[str]:
@@ -137,11 +136,6 @@ def compare_extraction(
     LOGGER.debug("extracted length: %s (algorithm) %s (extraction)", len_algo, len_text)
 
     use_readability = _prefer_readability(body, temppost_algo, algo_text, len_text, len_algo, options)
-    if use_readability and _requested_structure(body, options):
-        # Compare the representation that would actually be returned. The raw readability
-        # tree still uses HTML tags (img/a/h1), while the main extractor uses graphic/ref/head.
-        structured_body, _, structured_len = sanitize_tree(copy(temppost_algo), options)
-        use_readability = _prefer_fallback(body, len_text, structured_body, structured_len, options)
     if use_readability:
         body, text, len_text = temppost_algo, algo_text, len_algo
     LOGGER.debug("using %s extraction: %s", "generic" if use_readability else "custom", options.source)


### PR DESCRIPTION
Fixes #896.

Short documents can fall below `MIN_EXTRACTED_SIZE` even when the main
extractor found valid structured content. Justext or the baseline extractor
can then replace that result with equal or shorter plain text. This removes
images, links, headings, lists, and other formatting that callers explicitly
requested.

This change:

- rejects a Justext or baseline candidate when it loses requested structure
  without recovering more text;
- still accepts a longer candidate, so real content recovery continues to win;
- derives formatting structures from Trafilatura's existing tag catalog;
- adds regressions for images, links, Markdown headings, and longer JSON-LD
  recovery.

Readability selection is unchanged.

Verification:

- `pytest -q`: 337 passed, 1 skipped
- `ruff check .`: passed
- `ruff format --check trafilatura tests`: passed
- `python tests/eval_gate.py`: passed
  - `fast`: F1 0.9184
  - `fallback`: F1 0.9243
- AIKEK downstream `webfetch`: 98 passed
- Built-wheel test confirms the interleaved image contract is restored

`mypy -p trafilatura` still reports the existing `utils.py:56`
faust-cchardet mismatch, which also occurs on clean master.

Disclosure: prepared with AI assistance and reviewed and verified locally.
