### PR TITLE
Fix 2.2.0 regression dropping requested images

### DIFF
--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -3,6 +3,7 @@
 Unit tests for the trafilatura library.
 """
 
+import json
 import logging
 import sys
 import time
@@ -2215,6 +2216,36 @@ def test_include_images_does_not_truncate():
     result = extract(doc, output_format="txt", include_images=True, config=real_config) or ""
     assert "/lead.jpg" in result
     assert all(f"Continuation paragraph {i}" in result for i in range(1, 5))
+
+
+def test_short_document_fallback_preserves_image():
+    """A text-only fallback must not erase a requested image when it recovers no text."""
+    first = (
+        "Some reasonably long paragraph of body text that trafilatura will keep because it "
+        "is clearly the main content of this document and not navigation furniture."
+    )
+    second = "A second paragraph that follows the figure and continues the argument at length."
+    doc = (
+        f"<html><body><article><p>{first}</p>"
+        '<img src="https://cdn.test/a.png" alt="a chart"/>'
+        f"<p>{second}</p></article></body></html>"
+    )
+    result = extract(doc, output_format="xml", include_images=True, include_links=True, config=use_config()) or ""
+    assert '<graphic src="https://cdn.test/a.png" alt="a chart"/>' in result
+
+
+def test_longer_fallback_can_replace_requested_image():
+    """A real content recovery still wins even when its source cannot preserve an image."""
+    recovered = "Recovered canonical article body with meaningful information and complete sentences. " * 12
+    payload = json.dumps({"@type": "Article", "articleBody": recovered})
+    doc = (
+        f'<html><head><script type="application/ld+json">{payload}</script></head><body><article>'
+        '<p>A short visible article paragraph below the extraction threshold.</p><img src="chart.png" alt="chart"/>'
+        "</article></body></html>"
+    )
+    result = extract(doc, output_format="xml", include_images=True, config=use_config()) or ""
+    assert "Recovered canonical article body" in result
+    assert "<graphic" not in result
 
 
 def test_no_duplicate_content():

--- a/trafilatura/core.py
+++ b/trafilatura/core.py
@@ -232,9 +232,11 @@ def trafilatura_sequence(
 
     # 3. rescue: baseline on the original tree
     if len_text < options.min_extracted_size and options.focus != "precision":
-        postbody, temp_text, len_text = baseline(tree)  # baseline copies element inputs
-        LOGGER.debug("non-clean extracted length: %s (extraction)", len_text)
-        forum_posts = None  # the dump saw the whole page: missing posts are boilerplate, not lost
+        b_body, b_text, b_len = baseline(tree)  # baseline copies element inputs
+        if b_len > len_text or not options.images or postbody.find(".//graphic") is None:
+            postbody, temp_text, len_text = b_body, b_text, b_len
+            forum_posts = None  # the dump saw the whole page: missing posts are boilerplate, not lost
+        LOGGER.debug("non-clean extracted length: %s (extraction)", b_len)
 
     # 4. recall escalation: a short extraction covering little of the page suggests
     # under-extraction (non-article layout) — retry in recall mode, keep if clearly bigger.

--- a/trafilatura/external.py
+++ b/trafilatura/external.py
@@ -109,7 +109,11 @@ def compare_extraction(
         LOGGER.debug("unclean document triggering justext examination: %s", options.source)
         body2, text2, len_text2 = justext_rescue(cleaned_tree, options)
         # prevent too short documents from replacing the main text
-        if text2 and len_text <= JUSTEXT_OVERRIDE_RATIO * len_text2:
+        if (
+            text2
+            and len_text <= JUSTEXT_OVERRIDE_RATIO * len_text2
+            and (len_text2 > len_text or not options.images or body.find(".//graphic") is None)
+        ):
             LOGGER.debug("using justext, length: %s", len_text2)
             body, text, len_text = body2, text2, len_text2
             jt_result = True


### PR DESCRIPTION
This fixes a regression in Trafilatura 2.2.0. Short documents containing
requested images can be replaced by equal or shorter text-only fallbacks,
which removes `<graphic>` elements from XML output despite
`include_images=True`.

## Reproduction

```python
import trafilatura

html = """
<html><body><article>
  <p>Some reasonably long paragraph of body text that trafilatura will keep because it
  is clearly the main content of this document and not navigation furniture.</p>
  <img src="https://cdn.test/a.png" alt="a chart">
  <p>A second paragraph that follows the figure and continues the argument at length.</p>
</article></body></html>
"""

print(trafilatura.extract(
    html,
    output_format="xml",
    include_images=True,
    include_links=True,
))
```

Run the script against both releases:

```console
uv run --isolated --no-project --with trafilatura==2.1.0 python repro.py
uv run --isolated --no-project --with trafilatura==2.2.0 python repro.py
```

Observed results:

- 2.1.0 includes `<graphic src="https://cdn.test/a.png" alt="a chart"/>`.
  It also exhibits the older duplicate-text behavior.
- 2.2.0 returns one text-only paragraph and omits `<graphic>`.
- This PR preserves `<graphic>` without restoring the duplicated text.

The extracted text is shorter than the default `MIN_EXTRACTED_SIZE`. Justext
and then the baseline extractor can replace the structured result even when
they do not recover more text.

This change keeps an existing image when a text fallback does not recover more
text. A longer fallback still wins, so genuine content recovery is unchanged.

## Verification

- `pytest -q`: 335 passed, 1 skipped
- `ruff check .`: passed
- `ruff format --check trafilatura tests`: passed
- `python tests/eval_gate.py`: passed
  - `fast`: F1 0.9184
  - `fallback`: F1 0.9243

Disclosure: prepared with AI assistance and reviewed and verified locally.
