### PR TITLE
fix(baseline): space block boundaries in the article tier (#896)

### DIFF
--- a/tests/baseline_tests.py
+++ b/tests/baseline_tests.py
@@ -437,6 +437,53 @@ def test_baseline_article_dominance():
     assert all(post.format(i) in result2 for i in range(3))
 
 
+def test_baseline_article_block_boundaries():
+    "regression (#896): the article strategy fused the text of adjacent block elements -- a \
+    minified <article> carries no whitespace between </h1> and its <p>, so text_content() ran \
+    them together as 'Notice TitleMunicipal...'. Mirrors the block-spacing assertions in \
+    test_html2txt: block boundaries separate, inline runs inside a block stay joined."
+    # padded past the one hundred character gate so the article strategy accepts the text
+    para = "Municipal notice body sentence carrying the real page content here. " * 2
+    doc = f"<html><body><article><h1>Notice Title</h1><p>{para}</p><p>Hyper<b>link</b></p></article></body></html>"
+    _, text, _ = baseline(doc)
+    assert "TitleMunicipal" not in text  # block boundary no longer fused
+    assert "Notice Title Municipal notice body" in text
+    assert "Hyperlink" in text  # inline run inside a block stays joined
+
+
+_ARTICLE_BODY = "The article body text continues here with enough words to clear the length gate. " * 2
+
+
+@pytest.mark.parametrize(
+    "inner",
+    [
+        "<h2>Section Heading</h2><p>{body}</p>",
+        "<ul><li>Section Heading</li><li>{body}</li></ul>",
+        "<table><tr><td>Section Heading</td><td>{body}</td></tr></table>",
+    ],
+    ids=["h2_p", "li_li", "td_td"],
+)
+def test_baseline_article_spacing_covers_all_block_elements(inner):
+    "regression (#896): the fusion is not specific to the <h1> of the report -- every block \
+    boundary inside the article ran together, h2/p/li/td alike, so the spacing pass applies to \
+    the whole _BLOCK_ELEMS set rather than to headings only."
+    doc = f"<html><body><article>{inner.format(body=_ARTICLE_BODY)}</article></body></html>"
+    _, text, _ = baseline(doc)
+    assert "HeadingThe" not in text
+    assert "Section Heading The article body text" in text
+
+
+def test_spaced_text_content_does_not_mutate_input():
+    "the article tier's spacing pass writes .text/.tail, so _spaced_text_content must work \
+    on a copy -- baseline() shares one tree across all its strategies."
+    from trafilatura.baseline import _spaced_text_content
+
+    elem = html.fromstring("<article><h1>A</h1><p>B</p></article>")
+    before = html.tostring(elem)
+    _spaced_text_content(elem)
+    assert html.tostring(elem) == before
+
+
 def test_html2txt():
     mydoc = "<html><body>Here is the body text</body></html>"
     assert html2txt(mydoc) == "Here is the body text"

--- a/trafilatura/baseline.py
+++ b/trafilatura/baseline.py
@@ -6,7 +6,7 @@ Module regrouping baseline and basic extraction functions.
 import json
 import re
 from collections.abc import Iterable
-from copy import copy
+from copy import copy, deepcopy
 from html import unescape
 from typing import Any
 
@@ -198,7 +198,8 @@ def baseline(filecontent: Any) -> tuple[_Element, str, int]:
     article_texts = [
         text
         for elem in tree.xpath(".//article[not(ancestor::article)]")
-        if len(text := trim(elem.text_content())) > _MIN_CONTENT_LENGTH
+        # spaced text: without it the text of adjacent elements fuses ("TitleThis body...")
+        if len(text := trim(_spaced_text_content(elem))) > _MIN_CONTENT_LENGTH
     ]
     if article_texts:
         # never None: the longest article passes both its own length gate and the cutoff
@@ -268,6 +269,29 @@ _BLOCK_ELEMS = {
 }
 
 
+def _space_block_boundaries(elem: HtmlElement) -> None:
+    """Pad block-element boundaries with spaces so adjacent text runs don't stick
+    together in text_content() (minified pages carry no whitespace there).
+
+    Modifies the element in place -- use _spaced_text_content on a shared tree.
+    """
+    # remove_control_characters guards the .text write against chars lxml rejects
+    # (short-circuits on printable; str input pre-cleaned)
+    for block in elem.iter(*_BLOCK_ELEMS):
+        block.text = f" {remove_control_characters(block.text)}" if block.text else " "
+        block.tail = f" {remove_control_characters(block.tail)}" if block.tail else " "
+
+
+def _spaced_text_content(elem: HtmlElement) -> str:
+    """Text of an element, with block boundaries spaced so adjacent runs don't fuse.
+
+    Works on a copy, so it is safe on a tree shared with other extraction steps.
+    """
+    spaced = deepcopy(elem)
+    _space_block_boundaries(spaced)
+    return spaced.text_content()
+
+
 def html2txt(content: Any, clean: bool = True) -> str:
     """Run basic html2txt on a document.
 
@@ -293,9 +317,7 @@ def html2txt(content: Any, clean: bool = True) -> str:
         body = tree
     if clean:
         body = basic_cleaning(body)
-    # space block boundaries so adjacent runs don't stick (minified pages). remove_control_characters
-    # guards the .text write against chars lxml rejects (short-circuits on printable; str input pre-cleaned)
-    for elem in body.iter(*_BLOCK_ELEMS):
-        elem.text = f" {remove_control_characters(elem.text)}" if elem.text else " "
-        elem.tail = f" {remove_control_characters(elem.tail)}" if elem.tail else " "
+    # space block boundaries so adjacent runs don't stick (minified pages); the tree
+    # here is freshly parsed or already copied, so it can be modified in place
+    _space_block_boundaries(body)
     return " ".join(body.text_content().split())


### PR DESCRIPTION
Fixes #896 (the fusion half; see Scope below).

## Problem

The `<article>` tier called `text_content()` on the whole subtree, so text ran together across block boundaries. `<h1>Notice Title</h1><p>This ...` came out as `Notice TitleThis ...`, corrupting the words themselves rather than merely dropping formatting.

The same failure mode is already handled a few lines down in the same file: `html2txt()` pads block boundaries via `_BLOCK_ELEMS` before reading text, with a comment naming this exact case. The other baseline tiers avoid it structurally — the paragraph tier calls `text_content()` per element and joins with `"\n"`, the default tier uses `itertext()`. Only the `<article>` tier calls it on a whole subtree, so every block boundary inside the article fuses: h2 / p / li / td alike, not just the h1 in the report.

## Change

Extract the spacing pass into `_space_block_boundaries()` and call it from both sites, so the loop body exists once rather than being duplicated.

The article tier goes through `_spaced_text_content()`, which applies it to a `deepcopy`: the pass writes `.text`/`.tail`, and `baseline()` shares one tree across all its strategies. `html2txt()`'s tree is freshly parsed or already copied, so it spaces the body in place and pays no copy cost.

Per your guidance in #896 this reuses the existing pass rather than restructuring the tier to build the body per block element.

## Scope

The fusion only. The missing Markdown heading also reported in #896 originates earlier, in the stage 2 comparison as @ebarkhordar showed, and is not addressed here.

## Threshold and benchmark impact

You asked for the evaluation data on the cutoff question. Measured on the bundled corpus (990 documents), comparing 2ba8f62 against the same tree with this change applied. Python 3.12, Windows, `pip install -e ".[all]"`.

**`baseline()` output length**

| | count | share |
|---|---|---|
| unchanged | 678 / 990 | 68.5% |
| increased | 311 / 990 | 31.4% |
| decreased | 1 / 990 | 0.1% |

Deltas over the 312 changed documents: min −1, median +8, max +908.

The single decrease is `anglerboard.de-rute.html` (4312 → 4311): the article now goes through `remove_control_characters`, which drops one U+200B that raw `text_content()` kept. That is the existing guard doing its job, not lost content.

**Strategy selection** — no document changed tier. Identical before and after: article 527, paragraph 369, json 77, default 17.

**Threshold crossings**

| threshold | location | crossings |
|---|---|---|
| `_MIN_CONTENT_LENGTH = 100` | baseline.py:52 | 4 admitted, 0 rejected |
| `cutoff = max/5` | baseline.py:206 | 0 documents |
| `MIN_EXTRACTED_SIZE = 250` | settings.cfg:26 | 0 in either direction |

The four newly admitted candidates (100→102, 98→101, 100→101, 100→101) are small related-content blocks in pages carrying a much larger dominant article, so the `max/5` cutoff drops them again. The selected article set is unchanged in all 990 documents.

**End-to-end `extract()`**, comparing SHA-1 of the output: 4 / 990 documents changed, the same four under both runners.

| document | `extract()` |
|---|---|
| archive.org.swap-stop.org.shuji.html | 506 → 517 |
| caymancompass.com-prison.html | 1164 → 1180 |
| knowledge-on-air.de.koa039.html | 447 → 452 |
| sprechblase.wordpress.com.zapfsaeulen.html | 481 → 492 |

All four are short pages where the main extractor falls under `MIN_EXTRACTED_SIZE` and stage 3 hands over to `baseline()` — the path #896 reports. They gain only the separators that were missing at block boundaries. The remaining 986 are byte-identical.

**Quality gate** (`tests/eval_gate.py`)

| | fast | fallback |
|---|---|---|
| before (2ba8f62) | 0.9184 | 0.9243 |
| after (this PR) | 0.9184 | 0.9243 |
| pinned floor | 0.9180 | 0.9245 |

F1 is unchanged to four decimal places on both runners, and the gate exits 0 in both states. The before/after runs were taken by stashing only `trafilatura/baseline.py`; re-running after restoring reproduced the "after" numbers exactly.

One caveat rather than leave it implicit: `fallback` measures 0.9243 against a pinned floor of 0.9245 — 0.0002 under, inside the gate's `EPSILON = 0.0005` band, so it passes. That is equally true before the change, so it looks like a property of this measurement environment rather than something this PR introduces.

## Tests

Three tests in `tests/baseline_tests.py`. Full suite: 339 passed, 0 skipped.

Stashing the implementation and re-running turns 5 of them red, which is how the "h2/p/li/td alike" claim above was checked rather than assumed:

- `test_baseline_article_block_boundaries` — h1/p fusion, and that inline runs inside a block stay joined
- `test_baseline_article_spacing_covers_all_block_elements[h2_p|li_li|td_td]` — all three reproduce the fusion without the fix
- `test_spaced_text_content_does_not_mutate_input` — removing the `deepcopy` alone is enough to turn this one red

A note on that last one. An earlier version asserted non-mutation through `baseline()` instead, and it passed with the `deepcopy` removed — the later tiers run `trim()` per element, which absorbs the injected spaces. It was guarding nothing. Calling `_spaced_text_content` directly and comparing `tostring()` is what makes it fail on the mutation it is meant to catch.

`ruff check`, `ruff format --check` and `mypy -p trafilatura` show nothing new; the pre-existing `zstandard` note in `utils.py:38` is unrelated.

## Disclosure

Prepared with AI assistance. The design decisions, the scope boundary and every number above are mine — the measurements were run locally on the bundled corpus, and the before/after comparisons were taken by stashing only `trafilatura/baseline.py`.
