### PR TITLE
fix: type cchardet_detect as optional so the type check passes

### DIFF
--- a/trafilatura/utils.py
+++ b/trafilatura/utils.py
@@ -23,7 +23,7 @@ except ImportError:
 
 from functools import lru_cache
 from itertools import islice
-from typing import TYPE_CHECKING, Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, cast
 from unicodedata import normalize
 
 # response compression
@@ -49,18 +49,21 @@ try:
 except ImportError:
     LANGID_FLAG = False
 
-# CChardet is faster and can be more accurate
-try:
-    from cchardet import detect as cchardet_detect
-except ImportError:
-    cchardet_detect = None
-
 from charset_normalizer import from_bytes
 from lxml.etree import _Element
 from lxml.html import HtmlElement, HTMLParser, fromstring
 
 # response types
 from urllib3.response import HTTPResponse
+
+# CChardet is faster and can be more accurate
+cchardet_detect: Optional[Callable[[bytes], Any]]
+try:
+    from cchardet import detect
+
+    cchardet_detect = detect
+except ImportError:
+    cchardet_detect = None
 
 if TYPE_CHECKING:  # pragma: no cover
     from .settings import Document, Extractor


### PR DESCRIPTION
Noticed while working on #902 — the type check has been failing on master
since 2026-08-10, which is unrelated to that PR.

    trafilatura/utils.py:56: error: Incompatible types in assignment
      (expression has type "None", variable has type "Callable[[bytes], DetectionResult]")

The cause is faust-cchardet 3.2.0 (released 2026-08-10 02:54 UTC), which added
`py.typed` and `_cchardet.pyi`. `detect` previously resolved to `Any`, so the
`None` fallback was accepted; now that it is typed, the mismatch surfaces. mypy
itself is unchanged — 2.3.0 on both the last passing and first failing run. The
`cchardet` entry under `ignore_missing_imports` in pyproject.toml no longer has
any effect, since the package now ships its own types.

Because the type check runs before pytest, `build (ubuntu-latest, 3.13, false)`
also skips the test run, the evaluation gate, the docs test and the coverage
upload on that configuration.

### Change

`cchardet_detect` is declared `Optional[Callable[[bytes], Any]]` — what
`detect_encoding()` already assumes, since it guards with `is not None`. The
block moves below the remaining imports so the declaration does not make those
imports trigger E402.

### Verification

mypy 2.3.0, `.[all,dev]`:

- `mypy -p trafilatura` — success with faust-cchardet 3.1.0 and 3.2.0
  (fails on 3.2.0 without this change, passes on 3.1.0 — same mypy, same code)
- `ruff check .` — passed; `ruff format --check` — 42 files already formatted
- `pytest` — 333 passed, 1 skipped
- `detect_encoding()` returns the same results with cchardet installed and with
  the import blocked to force the fallback

Happy to adjust the approach if you would prefer it handled differently.
