### PR TITLE
fix: decompress zstd frames without a declared content size

### DIFF
--- a/tests/downloads_tests.py
+++ b/tests/downloads_tests.py
@@ -293,6 +293,12 @@ def test_config():
     assert custom["Cookie"] == "yummy_cookie=choco; tasty_cookie=strawberry"
 
 
+def zstd_stream_compress(data: bytes) -> bytes:
+    "Compress data into a zstd frame which does not declare its content size."
+    chunker = zstandard.ZstdCompressor().chunker()
+    return b"".join(chunker.compress(data)) + b"".join(chunker.finish())
+
+
 def test_decode():
     """Test how responses are being decoded."""
     html_string = "<html><head/><body><div>ABC</div></body></html>"
@@ -306,13 +312,25 @@ def test_decode():
         compressed_strings.append(brotli.compress(html_string.encode("utf-8")))
     if HAS_ZSTD:
         compressed_strings.append(zstandard.compress(html_string.encode("utf-8")))
+        # servers compressing on the fly emit frames without a declared content
+        # size, and concatenated frames are equally valid
+        compressed_strings.append(zstd_stream_compress(html_string.encode("utf-8")))
+        compressed_strings.append(
+            zstandard.compress(html_string[:20].encode("utf-8")) + zstandard.compress(html_string[20:].encode("utf-8"))
+        )
 
     for compressed_string in compressed_strings:
         assert handle_compressed_file(compressed_string) == html_string.encode("utf-8")
         assert decode_file(compressed_string) == html_string
 
     # errors
-    for bad_file in ("äöüß", b"\x1f\x8b\x08abc", b"\x28\xb5\x2f\xfdabc"):
+    bad_files = ["äöüß", b"\x1f\x8b\x08abc", b"\x28\xb5\x2f\xfdabc"]
+    if HAS_ZSTD:
+        # a truncated frame decompresses to a prefix, which must not be mistaken
+        # for the whole document
+        truncated = zstd_stream_compress(html_string.encode("utf-8") * 500)
+        bad_files.append(truncated[: len(truncated) // 2])
+    for bad_file in bad_files:
         assert handle_compressed_file(bad_file) == bad_file
 
 

--- a/tests/downloads_tests.py
+++ b/tests/downloads_tests.py
@@ -330,6 +330,12 @@ def test_decode():
         # for the whole document
         truncated = zstd_stream_compress(html_string.encode("utf-8") * 500)
         bad_files.append(truncated[: len(truncated) // 2])
+        # reserved bit set in the frame header descriptor (the byte after the
+        # magic): rejected by the decompressor itself rather than by the
+        # end-of-frame check
+        frame = bytearray(zstandard.compress(html_string.encode("utf-8")))
+        frame[4] |= 0x08
+        bad_files.append(bytes(frame))
     for bad_file in bad_files:
         assert handle_compressed_file(bad_file) == bad_file
 

--- a/trafilatura/utils.py
+++ b/trafilatura/utils.py
@@ -143,6 +143,25 @@ RE_FILTER = re.compile(
 LINK_FARM_RATIO = 0.9
 
 
+def _decompress_zstd(filecontent: bytes) -> bytes | None:
+    """Decompress a Zstandard payload, or return None if it is not intact.
+    The one-shot API only accepts frames declaring their decompressed size in
+    the header, which servers compressing their responses on the fly omit."""
+    chunks: list[bytes] = []
+    remaining = filecontent
+    while remaining:
+        decompressor = zstandard.ZstdDecompressor().decompressobj()
+        try:
+            chunks.append(decompressor.decompress(remaining))
+        except zstandard.ZstdError:
+            return None
+        # a truncated frame decompresses to a plausible-looking prefix, reject it
+        if not decompressor.eof:
+            return None
+        remaining = decompressor.unused_data
+    return b"".join(chunks)
+
+
 def handle_compressed_file(filecontent: bytes) -> bytes:
     """
     Don't trust response headers and try to decompress a binary string
@@ -159,10 +178,10 @@ def handle_compressed_file(filecontent: bytes) -> bytes:
             LOGGER.warning("invalid GZ file")
     # try zstandard
     if HAS_ZSTD and filecontent[:4] == b"\x28\xb5\x2f\xfd":
-        try:
-            return zstandard.decompress(filecontent)  # max_output_size=???
-        except zstandard.ZstdError:
-            LOGGER.warning("invalid ZSTD file")
+        decompressed = _decompress_zstd(filecontent)
+        if decompressed is not None:
+            return decompressed
+        LOGGER.warning("invalid ZSTD file")
     # try brotli
     if HAS_BROTLI:
         try:


### PR DESCRIPTION
Fixes #912.

### The bug

`handle_compressed_file()` used the one-shot `zstandard.decompress()`, which
requires the frame header to declare the decompressed size. Servers that
compress responses on the fly omit it, so the call raised `ZstdError`, the
warning was logged, and the function fell through to returning the payload
unchanged. `decode_file()` then string-decoded the compressed bytes, so a
caller received a plausible-looking non-empty `str` while `extract()` returned
`None` — with nothing logged above `WARNING` to signal it.

Checked against the four sites named in the issue. On `master` all four come
back as the zstd magic lossily decoded to a `str` and extract to nothing;
with this change they extract 18421 / 25598 / 4732 / 9178 characters.

### The fix

Decompress through a streaming decompressor, which does not need the size up
front, and iterate over `unused_data` so concatenated frames are handled as
well.

A payload whose last frame never reaches `eof` is rejected. This part matters:
the obvious alternative, `stream_reader(..., read_across_frames=True).read()`,
returns a *partial* document for a truncated frame rather than raising — a
half-received response would have been silently accepted as complete, trading
one silent failure for a worse one. Measured on a truncated multi-block
payload it returns 786 KB of a 1.7 MB document with no error.

### Tests

The existing case only covered `zstandard.compress()`, which does declare the
size — hence the gap. Added coverage for a streamed frame, concatenated
frames, and a truncated frame that must not be accepted. The new assertions
fail on `master` and pass with this change.

`pytest` (343 passed), `mypy -p trafilatura`, `ruff check`, `ruff format
--check` and `tests/eval_gate.py` (F1 unchanged at the pinned floor) are all
clean.

### Note on the downloaders

I left both downloaders alone. `handle_compressed_file()` is the common
chokepoint — it deliberately does not trust response headers — so fixing it
covers the pycurl and urllib3 paths at once. The commented-out
`CURLOPT_ACCEPT_ENCODING` in `_send_pycurl_request` looks like a deliberate
choice and is a separate performance question, not a correctness one.
